### PR TITLE
Add TypeScript JSONL parser (Unit 3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ __pycache__/
 .squall/
 *.jsonl
 *.html
+node_modules/
+dist/

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,259 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "convo-viewer",
+      "dependencies": {
+        "commander": "^12",
+      },
+      "devDependencies": {
+        "@types/node": "^22",
+        "esbuild": "^0.24",
+        "typescript": "^5.6",
+        "vitest": "^2",
+      },
+    },
+  },
+  "packages": {
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.24.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.24.2", "", { "os": "android", "cpu": "arm" }, "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.24.2", "", { "os": "android", "cpu": "arm64" }, "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.24.2", "", { "os": "android", "cpu": "x64" }, "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.24.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.24.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.24.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.24.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.24.2", "", { "os": "linux", "cpu": "arm" }, "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.24.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.24.2", "", { "os": "linux", "cpu": "ia32" }, "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.24.2", "", { "os": "linux", "cpu": "none" }, "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.24.2", "", { "os": "linux", "cpu": "none" }, "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.24.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.24.2", "", { "os": "linux", "cpu": "none" }, "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.24.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.24.2", "", { "os": "linux", "cpu": "x64" }, "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.24.2", "", { "os": "none", "cpu": "arm64" }, "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.24.2", "", { "os": "none", "cpu": "x64" }, "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.24.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.24.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.24.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.24.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.24.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.24.2", "", { "os": "win32", "cpu": "x64" }, "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.59.0", "", { "os": "android", "cpu": "arm" }, "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.59.0", "", { "os": "android", "cpu": "arm64" }, "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.59.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.59.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.59.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.59.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.59.0", "", { "os": "linux", "cpu": "arm" }, "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.59.0", "", { "os": "linux", "cpu": "arm" }, "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.59.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.59.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.59.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.59.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.59.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.59.0", "", { "os": "linux", "cpu": "x64" }, "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.59.0", "", { "os": "linux", "cpu": "x64" }, "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.59.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.59.0", "", { "os": "none", "cpu": "arm64" }, "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.59.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.59.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/node": ["@types/node@22.19.15", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg=="],
+
+    "@vitest/expect": ["@vitest/expect@2.1.9", "", { "dependencies": { "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw=="],
+
+    "@vitest/mocker": ["@vitest/mocker@2.1.9", "", { "dependencies": { "@vitest/spy": "2.1.9", "estree-walker": "^3.0.3", "magic-string": "^0.30.12" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@2.1.9", "", { "dependencies": { "tinyrainbow": "^1.2.0" } }, "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ=="],
+
+    "@vitest/runner": ["@vitest/runner@2.1.9", "", { "dependencies": { "@vitest/utils": "2.1.9", "pathe": "^1.1.2" } }, "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@2.1.9", "", { "dependencies": { "@vitest/pretty-format": "2.1.9", "magic-string": "^0.30.12", "pathe": "^1.1.2" } }, "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ=="],
+
+    "@vitest/spy": ["@vitest/spy@2.1.9", "", { "dependencies": { "tinyspy": "^3.0.2" } }, "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ=="],
+
+    "@vitest/utils": ["@vitest/utils@2.1.9", "", { "dependencies": { "@vitest/pretty-format": "2.1.9", "loupe": "^3.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
+    "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
+
+    "commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
+    "esbuild": ["esbuild@0.24.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.24.2", "@esbuild/android-arm": "0.24.2", "@esbuild/android-arm64": "0.24.2", "@esbuild/android-x64": "0.24.2", "@esbuild/darwin-arm64": "0.24.2", "@esbuild/darwin-x64": "0.24.2", "@esbuild/freebsd-arm64": "0.24.2", "@esbuild/freebsd-x64": "0.24.2", "@esbuild/linux-arm": "0.24.2", "@esbuild/linux-arm64": "0.24.2", "@esbuild/linux-ia32": "0.24.2", "@esbuild/linux-loong64": "0.24.2", "@esbuild/linux-mips64el": "0.24.2", "@esbuild/linux-ppc64": "0.24.2", "@esbuild/linux-riscv64": "0.24.2", "@esbuild/linux-s390x": "0.24.2", "@esbuild/linux-x64": "0.24.2", "@esbuild/netbsd-arm64": "0.24.2", "@esbuild/netbsd-x64": "0.24.2", "@esbuild/openbsd-arm64": "0.24.2", "@esbuild/openbsd-x64": "0.24.2", "@esbuild/sunos-x64": "0.24.2", "@esbuild/win32-arm64": "0.24.2", "@esbuild/win32-ia32": "0.24.2", "@esbuild/win32-x64": "0.24.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
+
+    "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
+
+    "rollup": ["rollup@4.59.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.59.0", "@rollup/rollup-android-arm64": "4.59.0", "@rollup/rollup-darwin-arm64": "4.59.0", "@rollup/rollup-darwin-x64": "4.59.0", "@rollup/rollup-freebsd-arm64": "4.59.0", "@rollup/rollup-freebsd-x64": "4.59.0", "@rollup/rollup-linux-arm-gnueabihf": "4.59.0", "@rollup/rollup-linux-arm-musleabihf": "4.59.0", "@rollup/rollup-linux-arm64-gnu": "4.59.0", "@rollup/rollup-linux-arm64-musl": "4.59.0", "@rollup/rollup-linux-loong64-gnu": "4.59.0", "@rollup/rollup-linux-loong64-musl": "4.59.0", "@rollup/rollup-linux-ppc64-gnu": "4.59.0", "@rollup/rollup-linux-ppc64-musl": "4.59.0", "@rollup/rollup-linux-riscv64-gnu": "4.59.0", "@rollup/rollup-linux-riscv64-musl": "4.59.0", "@rollup/rollup-linux-s390x-gnu": "4.59.0", "@rollup/rollup-linux-x64-gnu": "4.59.0", "@rollup/rollup-linux-x64-musl": "4.59.0", "@rollup/rollup-openbsd-x64": "4.59.0", "@rollup/rollup-openharmony-arm64": "4.59.0", "@rollup/rollup-win32-arm64-msvc": "4.59.0", "@rollup/rollup-win32-ia32-msvc": "4.59.0", "@rollup/rollup-win32-x64-gnu": "4.59.0", "@rollup/rollup-win32-x64-msvc": "4.59.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+
+    "tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
+
+    "tinyrainbow": ["tinyrainbow@1.2.0", "", {}, "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ=="],
+
+    "tinyspy": ["tinyspy@3.0.2", "", {}, "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+
+    "vite-node": ["vite-node@2.1.9", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.3.7", "es-module-lexer": "^1.5.4", "pathe": "^1.1.2", "vite": "^5.0.0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA=="],
+
+    "vitest": ["vitest@2.1.9", "", { "dependencies": { "@vitest/expect": "2.1.9", "@vitest/mocker": "2.1.9", "@vitest/pretty-format": "^2.1.9", "@vitest/runner": "2.1.9", "@vitest/snapshot": "2.1.9", "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "debug": "^4.3.7", "expect-type": "^1.1.0", "magic-string": "^0.30.12", "pathe": "^1.1.2", "std-env": "^3.8.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.1", "tinypool": "^1.0.1", "tinyrainbow": "^1.2.0", "vite": "^5.0.0", "vite-node": "2.1.9", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "2.1.9", "@vitest/ui": "2.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
+    "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "convo-viewer",
+  "version": "2.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "commander": "^12"
+  },
+  "devDependencies": {
+    "@types/node": "^22",
+    "esbuild": "^0.24",
+    "typescript": "^5.6",
+    "vitest": "^2"
+  }
+}

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -1,0 +1,515 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { writeFileSync, unlinkSync, mkdtempSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { buildConversation } from "./parser.js";
+
+function writeTempJsonl(lines: unknown[]): string {
+  const dir = mkdtempSync(join(tmpdir(), "parser-test-"));
+  const file = join(dir, "test.jsonl");
+  writeFileSync(file, lines.map((l) => JSON.stringify(l)).join("\n") + "\n");
+  return file;
+}
+
+const tempFiles: string[] = [];
+
+function createJsonl(lines: unknown[]): string {
+  const f = writeTempJsonl(lines);
+  tempFiles.push(f);
+  return f;
+}
+
+afterEach(() => {
+  for (const f of tempFiles) {
+    try { unlinkSync(f); } catch { /* ignore */ }
+  }
+  tempFiles.length = 0;
+});
+
+describe("buildConversation", () => {
+  it("parses basic user + assistant messages", () => {
+    const file = createJsonl([
+      { type: "user", message: { content: "Hello" }, timestamp: "2024-01-01T00:00:00Z" },
+      { type: "assistant", message: { content: "Hi there!" }, timestamp: "2024-01-01T00:00:01Z" },
+    ]);
+    const conv = buildConversation(file);
+    expect(conv.turns).toHaveLength(2);
+    expect(conv.turns[0].role).toBe("user");
+    expect(conv.turns[0].blocks).toHaveLength(1);
+    expect(conv.turns[0].blocks[0]).toEqual({ type: "text", text: "Hello" });
+    expect(conv.turns[1].role).toBe("assistant");
+    expect(conv.turns[1].blocks[0]).toEqual({ type: "text", text: "Hi there!" });
+  });
+
+  it("extracts metadata (sessionId from root, model, cwd, version)", () => {
+    const file = createJsonl([
+      { type: "user", sessionId: "sess-123", cwd: "/home/user", version: "1.0.0", message: { content: "Hi", model: "claude-3" }, timestamp: "2024-06-01T12:00:00Z" },
+      { type: "assistant", message: { content: "Hello" }, timestamp: "2024-06-01T12:00:01Z" },
+    ]);
+    const conv = buildConversation(file);
+    expect(conv.sessionId).toBe("sess-123");
+    expect(conv.projectDir).toBe("/home/user");
+    expect(conv.version).toBe("1.0.0");
+    expect(conv.model).toBe("claude-3");
+    expect(conv.startTime).toBe("2024-06-01T12:00:00Z");
+  });
+
+  it("extracts sessionId from message.sessionId", () => {
+    const file = createJsonl([
+      { type: "user", message: { content: "Hi", sessionId: "msg-sess-456" }, timestamp: "2024-01-01T00:00:00Z" },
+    ]);
+    const conv = buildConversation(file);
+    expect(conv.sessionId).toBe("msg-sess-456");
+  });
+
+  it("prefers message.sessionId over root sessionId", () => {
+    const file = createJsonl([
+      { type: "user", sessionId: "root-id", message: { content: "Hi", sessionId: "msg-id" }, timestamp: "2024-01-01T00:00:00Z" },
+    ]);
+    const conv = buildConversation(file);
+    expect(conv.sessionId).toBe("msg-id");
+  });
+
+  it("handles string content for user and assistant", () => {
+    const file = createJsonl([
+      { type: "user", message: { content: "Question?" }, timestamp: "t1" },
+      { type: "assistant", message: { content: "Answer." }, timestamp: "t2" },
+    ]);
+    const conv = buildConversation(file);
+    expect(conv.turns[0].blocks[0]).toEqual({ type: "text", text: "Question?" });
+    expect(conv.turns[1].blocks[0]).toEqual({ type: "text", text: "Answer." });
+  });
+
+  it("handles array content with text blocks", () => {
+    const file = createJsonl([
+      {
+        type: "assistant",
+        message: {
+          content: [
+            { type: "text", text: "Part 1" },
+            { type: "text", text: "Part 2" },
+          ],
+        },
+        timestamp: "t1",
+      },
+    ]);
+    const conv = buildConversation(file);
+    expect(conv.turns[0].blocks).toHaveLength(2);
+    expect(conv.turns[0].blocks[0]).toEqual({ type: "text", text: "Part 1" });
+    expect(conv.turns[0].blocks[1]).toEqual({ type: "text", text: "Part 2" });
+  });
+
+  it("extracts tool_use blocks", () => {
+    const file = createJsonl([
+      {
+        type: "assistant",
+        message: {
+          content: [
+            { type: "tool_use", name: "read_file", input: { path: "/tmp/f" }, id: "tu-1" },
+          ],
+        },
+        timestamp: "t1",
+      },
+    ]);
+    const conv = buildConversation(file);
+    expect(conv.turns[0].blocks[0]).toEqual({
+      type: "tool_use",
+      name: "read_file",
+      input: { path: "/tmp/f" },
+      id: "tu-1",
+    });
+  });
+
+  it("extracts tool_result blocks with string content", () => {
+    const file = createJsonl([
+      {
+        type: "assistant",
+        message: { content: [{ type: "text", text: "Let me check." }] },
+        timestamp: "t1",
+      },
+      {
+        type: "user",
+        message: {
+          content: [
+            { type: "tool_result", content: "file contents here", tool_use_id: "tu-1" },
+          ],
+        },
+        timestamp: "t2",
+      },
+    ]);
+    const conv = buildConversation(file);
+    // Tool-result-only user message should be folded into assistant turn
+    expect(conv.turns).toHaveLength(1);
+    expect(conv.turns[0].blocks[1]).toEqual({
+      type: "tool_result",
+      content: "file contents here",
+      meta: null,
+      isError: false,
+      toolUseId: "tu-1",
+    });
+  });
+
+  it("extracts tool_result blocks with array content", () => {
+    const file = createJsonl([
+      {
+        type: "assistant",
+        message: { content: [{ type: "text", text: "Checking" }] },
+        timestamp: "t1",
+      },
+      {
+        type: "user",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              content: [
+                { type: "text", text: "line 1" },
+                { type: "text", text: "line 2" },
+              ],
+              tool_use_id: "tu-2",
+            },
+          ],
+        },
+        timestamp: "t2",
+      },
+    ]);
+    const conv = buildConversation(file);
+    expect(conv.turns).toHaveLength(1);
+    const block = conv.turns[0].blocks[1];
+    expect(block.type).toBe("tool_result");
+    if (block.type === "tool_result") {
+      expect(block.content).toBe("line 1\nline 2");
+      expect(block.meta).toBeNull();
+    }
+  });
+
+  it("separates tool_result metadata (agentId, usage)", () => {
+    const file = createJsonl([
+      {
+        type: "assistant",
+        message: { content: [{ type: "text", text: "Running" }] },
+        timestamp: "t1",
+      },
+      {
+        type: "user",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              content: [
+                { type: "text", text: "actual result" },
+                { type: "text", text: "agentId: agent-42" },
+                { type: "text", text: "<usage>some usage data</usage>" },
+              ],
+              tool_use_id: "tu-3",
+            },
+          ],
+        },
+        timestamp: "t2",
+      },
+    ]);
+    const conv = buildConversation(file);
+    const block = conv.turns[0].blocks[1];
+    expect(block.type).toBe("tool_result");
+    if (block.type === "tool_result") {
+      expect(block.content).toBe("actual result");
+      expect(block.meta).toBe("agentId: agent-42\n<usage>some usage data</usage>");
+    }
+  });
+
+  it("handles error tool results (is_error: true)", () => {
+    const file = createJsonl([
+      {
+        type: "assistant",
+        message: { content: [{ type: "text", text: "Trying" }] },
+        timestamp: "t1",
+      },
+      {
+        type: "user",
+        message: {
+          content: [
+            { type: "tool_result", content: "Error: file not found", is_error: true, tool_use_id: "tu-err" },
+          ],
+        },
+        timestamp: "t2",
+      },
+    ]);
+    const conv = buildConversation(file);
+    const block = conv.turns[0].blocks[1];
+    expect(block.type).toBe("tool_result");
+    if (block.type === "tool_result") {
+      expect(block.isError).toBe(true);
+      expect(block.content).toBe("Error: file not found");
+    }
+  });
+
+  it("detects slash commands", () => {
+    const file = createJsonl([
+      {
+        type: "user",
+        message: { content: "<command-name>/help</command-name><command-args>topic</command-args>" },
+        timestamp: "t1",
+      },
+    ]);
+    const conv = buildConversation(file);
+    expect(conv.turns[0].blocks[0]).toEqual({
+      type: "slash_command",
+      command: "/help topic",
+    });
+  });
+
+  it("detects slash command without args", () => {
+    const file = createJsonl([
+      {
+        type: "user",
+        message: { content: "<command-name>/clear</command-name>" },
+        timestamp: "t1",
+      },
+    ]);
+    const conv = buildConversation(file);
+    expect(conv.turns[0].blocks[0]).toEqual({
+      type: "slash_command",
+      command: "/clear",
+    });
+  });
+
+  it("detects session continuation", () => {
+    const file = createJsonl([
+      {
+        type: "user",
+        message: { content: "This session is being continued from a previous conversation. Here is the summary..." },
+        timestamp: "t1",
+      },
+    ]);
+    const conv = buildConversation(file);
+    expect(conv.turns[0].blocks[0]).toEqual({
+      type: "session_continuation",
+      text: "This session is being continued from a previous conversation. Here is the summary...",
+    });
+  });
+
+  it("filters system noise from user messages (skips entirely)", () => {
+    const file = createJsonl([
+      {
+        type: "user",
+        message: { content: "<system-reminder>You are a helpful assistant.</system-reminder>" },
+        timestamp: "t1",
+      },
+      { type: "assistant", message: { content: "Response" }, timestamp: "t2" },
+    ]);
+    const conv = buildConversation(file);
+    // The user turn should still exist but with no blocks (empty noise that's not slash/continuation)
+    // Actually: since isSystemNoise returns true and there's no command-name or session continuation,
+    // parsedBlocks is empty. The turn is created with empty blocks.
+    // Let's verify: the first turn is user with empty blocks, second is assistant.
+    expect(conv.turns).toHaveLength(2);
+    expect(conv.turns[0].role).toBe("user");
+    expect(conv.turns[0].blocks).toHaveLength(0);
+    expect(conv.turns[1].role).toBe("assistant");
+  });
+
+  it("filters system noise from array content user text blocks", () => {
+    const file = createJsonl([
+      {
+        type: "user",
+        message: {
+          content: [
+            { type: "text", text: "<system-reminder>noise</system-reminder>" },
+            { type: "text", text: "Real question" },
+          ],
+        },
+        timestamp: "t1",
+      },
+    ]);
+    const conv = buildConversation(file);
+    expect(conv.turns[0].blocks).toHaveLength(1);
+    expect(conv.turns[0].blocks[0]).toEqual({ type: "text", text: "Real question" });
+  });
+
+  it("folds tool_result-only user messages into preceding assistant turn", () => {
+    const file = createJsonl([
+      {
+        type: "assistant",
+        message: {
+          content: [
+            { type: "text", text: "Let me read that file." },
+            { type: "tool_use", name: "read", input: {}, id: "tu-10" },
+          ],
+        },
+        timestamp: "t1",
+      },
+      {
+        type: "user",
+        message: {
+          content: [
+            { type: "tool_result", content: "file data", tool_use_id: "tu-10" },
+          ],
+        },
+        timestamp: "t2",
+      },
+    ]);
+    const conv = buildConversation(file);
+    expect(conv.turns).toHaveLength(1);
+    expect(conv.turns[0].role).toBe("assistant");
+    expect(conv.turns[0].blocks).toHaveLength(3);
+    expect(conv.turns[0].blocks[2].type).toBe("tool_result");
+  });
+
+  it("does not fold tool_result user messages if they also have user text", () => {
+    const file = createJsonl([
+      {
+        type: "assistant",
+        message: { content: [{ type: "text", text: "Working..." }] },
+        timestamp: "t1",
+      },
+      {
+        type: "user",
+        message: {
+          content: [
+            { type: "tool_result", content: "result", tool_use_id: "tu-20" },
+            { type: "text", text: "Also, I have a question" },
+          ],
+        },
+        timestamp: "t2",
+      },
+    ]);
+    const conv = buildConversation(file);
+    expect(conv.turns).toHaveLength(2);
+    expect(conv.turns[1].role).toBe("user");
+  });
+
+  it("merges consecutive same-role messages into one turn", () => {
+    const file = createJsonl([
+      { type: "user", message: { content: "First message" }, timestamp: "t1" },
+      { type: "user", message: { content: "Second message" }, timestamp: "t2" },
+      { type: "assistant", message: { content: "Reply" }, timestamp: "t3" },
+    ]);
+    const conv = buildConversation(file);
+    expect(conv.turns).toHaveLength(2);
+    expect(conv.turns[0].role).toBe("user");
+    expect(conv.turns[0].blocks).toHaveLength(2);
+    expect(conv.turns[0].timestamp).toBe("t1"); // keeps first timestamp
+    expect(conv.turns[1].role).toBe("assistant");
+  });
+
+  it("skips malformed JSONL lines without crashing", () => {
+    const dir = mkdtempSync(join(tmpdir(), "parser-test-"));
+    const file = join(dir, "bad.jsonl");
+    const content = [
+      "not valid json",
+      JSON.stringify({ type: "user", message: { content: "Valid" }, timestamp: "t1" }),
+      "{broken",
+      JSON.stringify({ type: "assistant", message: { content: "Also valid" }, timestamp: "t2" }),
+    ].join("\n");
+    writeFileSync(file, content);
+    tempFiles.push(file);
+
+    const conv = buildConversation(file);
+    expect(conv.turns).toHaveLength(2);
+    expect(conv.turns[0].blocks[0]).toEqual({ type: "text", text: "Valid" });
+    expect(conv.turns[1].blocks[0]).toEqual({ type: "text", text: "Also valid" });
+  });
+
+  it("skips non-user/non-assistant message types", () => {
+    const file = createJsonl([
+      { type: "system", message: { content: "System prompt" }, timestamp: "t0" },
+      { type: "user", message: { content: "Hello" }, timestamp: "t1" },
+    ]);
+    const conv = buildConversation(file);
+    expect(conv.turns).toHaveLength(1);
+    expect(conv.turns[0].role).toBe("user");
+  });
+
+  it("handles thinking blocks", () => {
+    const file = createJsonl([
+      {
+        type: "assistant",
+        message: {
+          content: [
+            { type: "thinking", thinking: "Let me think about this..." },
+            { type: "text", text: "Here is my answer." },
+          ],
+        },
+        timestamp: "t1",
+      },
+    ]);
+    const conv = buildConversation(file);
+    expect(conv.turns[0].blocks).toHaveLength(2);
+    expect(conv.turns[0].blocks[0]).toEqual({ type: "thinking", text: "Let me think about this..." });
+    expect(conv.turns[0].blocks[1]).toEqual({ type: "text", text: "Here is my answer." });
+  });
+
+  it("extracts metadata from non-user/assistant lines", () => {
+    const file = createJsonl([
+      { type: "system", sessionId: "sess-from-system", cwd: "/project", version: "2.0" },
+      { type: "user", message: { content: "Hi", model: "claude-4" }, timestamp: "t1" },
+    ]);
+    const conv = buildConversation(file);
+    expect(conv.sessionId).toBe("sess-from-system");
+    expect(conv.projectDir).toBe("/project");
+    expect(conv.version).toBe("2.0");
+  });
+
+  it("returns null metadata when not present", () => {
+    const file = createJsonl([
+      { type: "user", message: { content: "Hi" }, timestamp: "t1" },
+    ]);
+    const conv = buildConversation(file);
+    expect(conv.sessionId).toBeNull();
+    expect(conv.projectDir).toBeNull();
+    expect(conv.model).toBeNull();
+    expect(conv.version).toBeNull();
+  });
+
+  it("handles empty file", () => {
+    const dir = mkdtempSync(join(tmpdir(), "parser-test-"));
+    const file = join(dir, "empty.jsonl");
+    writeFileSync(file, "");
+    tempFiles.push(file);
+
+    const conv = buildConversation(file);
+    expect(conv.turns).toHaveLength(0);
+    expect(conv.sessionId).toBeNull();
+  });
+
+  it("handles tool_result with string content in array items", () => {
+    const file = createJsonl([
+      {
+        type: "assistant",
+        message: { content: [{ type: "text", text: "Checking" }] },
+        timestamp: "t1",
+      },
+      {
+        type: "user",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              content: ["raw string item"],
+              tool_use_id: "tu-str",
+            },
+          ],
+        },
+        timestamp: "t2",
+      },
+    ]);
+    const conv = buildConversation(file);
+    const block = conv.turns[0].blocks[1];
+    expect(block.type).toBe("tool_result");
+    if (block.type === "tool_result") {
+      expect(block.content).toBe("raw string item");
+    }
+  });
+
+  it("cleans user text removing system noise tags but keeping real content", () => {
+    const file = createJsonl([
+      {
+        type: "user",
+        message: { content: "Hello <task-notification>ignored</task-notification> world" },
+        timestamp: "t1",
+      },
+    ]);
+    const conv = buildConversation(file);
+    expect(conv.turns[0].blocks[0]).toEqual({ type: "text", text: "Hello  world" });
+  });
+});

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,0 +1,195 @@
+import { readFileSync } from "fs";
+import type {
+  Block,
+  Conversation,
+  Turn,
+} from "./types.js";
+import { cleanUserText, isSystemNoise } from "./text-cleaning.js";
+
+export function buildConversation(inputFile: string): Conversation {
+  const fileContent = readFileSync(inputFile, "utf-8");
+  const lines = fileContent.split("\n");
+
+  const turns: Turn[] = [];
+  let currentTurn: Turn | null = null;
+  let sessionId: string | null = null;
+  let projectDir: string | null = null;
+  let model: string | null = null;
+  let startTime: string | null = null;
+  let version: string | null = null;
+
+  for (const line of lines) {
+    if (!line.trim()) continue;
+
+    let obj: Record<string, unknown>;
+    try {
+      obj = JSON.parse(line);
+    } catch {
+      continue;
+    }
+
+    const message = (obj.message as Record<string, unknown>) ?? {};
+
+    // Grab metadata on first occurrence
+    if (!sessionId) {
+      const msgSid = message.sessionId as string | undefined;
+      const rootSid = obj.sessionId as string | undefined;
+      if (msgSid) sessionId = msgSid;
+      else if (rootSid) sessionId = rootSid;
+    }
+    if (!projectDir && obj.cwd) {
+      projectDir = obj.cwd as string;
+    }
+    if (!version && obj.version) {
+      version = obj.version as string;
+    }
+
+    const msgType = obj.type as string | undefined;
+    if (msgType !== "user" && msgType !== "assistant") continue;
+
+    const content = (message.content as string | unknown[] | undefined) ?? "";
+    const timestamp = (obj.timestamp as string) ?? "";
+
+    if (!startTime && timestamp) {
+      startTime = timestamp;
+    }
+    if (!model && message.model) {
+      model = message.model as string;
+    }
+
+    let hasUserText = false;
+    let hasToolResults = false;
+    const parsedBlocks: Block[] = [];
+
+    if (typeof content === "string" && content.trim()) {
+      if (msgType === "user") {
+        const cmdMatch = content.match(/<command-name>\s*(\/[\w-]+)\s*<\/command-name>/);
+        const cmdArgsMatch = content.match(/<command-args>\s*([\s\S]*?)\s*<\/command-args>/);
+
+        if (isSystemNoise(content)) {
+          if (cmdMatch) {
+            const cmd = cmdMatch[1];
+            const args = cmdArgsMatch ? cmdArgsMatch[1].trim() : "";
+            const label = args ? `${cmd} ${args}`.trim() : cmd;
+            parsedBlocks.push({ type: "slash_command", command: label });
+            hasUserText = true;
+          } else if (content.trim().startsWith("This session is being continued")) {
+            parsedBlocks.push({ type: "session_continuation", text: content.trim() });
+            hasUserText = true;
+          }
+          // Otherwise skip entirely
+        } else {
+          const cleaned = cleanUserText(content);
+          if (cleaned) {
+            hasUserText = true;
+            parsedBlocks.push({ type: "text", text: cleaned });
+          }
+        }
+      } else {
+        hasUserText = true;
+        parsedBlocks.push({ type: "text", text: content });
+      }
+    } else if (Array.isArray(content)) {
+      for (const item of content) {
+        if (typeof item !== "object" || item === null || Array.isArray(item)) continue;
+        const block = item as Record<string, unknown>;
+        const blockType = (block.type as string) ?? "";
+
+        if (blockType === "text") {
+          const text = (block.text as string) ?? "";
+          if (text.trim()) {
+            if (msgType === "user") {
+              if (isSystemNoise(text)) continue;
+              const cleaned = cleanUserText(text);
+              if (cleaned) {
+                hasUserText = true;
+                parsedBlocks.push({ type: "text", text: cleaned });
+              }
+            } else {
+              hasUserText = true;
+              parsedBlocks.push({ type: "text", text });
+            }
+          }
+        } else if (blockType === "thinking") {
+          const thinking = (block.thinking as string) ?? "";
+          if (thinking.trim()) {
+            parsedBlocks.push({ type: "thinking", text: thinking });
+          }
+        } else if (blockType === "tool_use") {
+          parsedBlocks.push({
+            type: "tool_use",
+            name: (block.name as string) ?? "unknown",
+            input: (block.input as Record<string, unknown>) ?? {},
+            id: (block.id as string) ?? "",
+          });
+        } else if (blockType === "tool_result") {
+          hasToolResults = true;
+          const resultContent = (block.content as string | unknown[] | undefined) ?? "";
+          const isError = (block.is_error as boolean) ?? false;
+
+          let resultText: string;
+          let metaText: string | null = null;
+
+          if (Array.isArray(resultContent)) {
+            const textParts: string[] = [];
+            const metaParts: string[] = [];
+            for (const rc of resultContent) {
+              if (typeof rc === "object" && rc !== null && !Array.isArray(rc)) {
+                const rcObj = rc as Record<string, unknown>;
+                if (rcObj.type === "text") {
+                  const t = (rcObj.text as string) ?? "";
+                  if (t.trim().startsWith("agentId:") || t.trim().startsWith("<usage>")) {
+                    metaParts.push(t);
+                  } else {
+                    textParts.push(t);
+                  }
+                }
+              } else if (typeof rc === "string") {
+                textParts.push(rc);
+              }
+            }
+            resultText = textParts.join("\n");
+            metaText = metaParts.length > 0 ? metaParts.join("\n") : null;
+          } else {
+            resultText = typeof resultContent === "string" ? resultContent : String(resultContent);
+          }
+
+          parsedBlocks.push({
+            type: "tool_result",
+            content: resultText,
+            meta: metaText,
+            isError,
+            toolUseId: (block.tool_use_id as string) ?? "",
+          });
+        }
+      }
+    }
+
+    // Tool result folding: user messages with only tool_results merge into preceding assistant turn
+    if (msgType === "user" && hasToolResults && !hasUserText) {
+      if (currentTurn && currentTurn.role === "assistant") {
+        currentTurn.blocks.push(...parsedBlocks);
+        continue;
+      }
+    }
+
+    const role = msgType as "user" | "assistant";
+
+    // Merge consecutive same-role messages into one turn
+    if (currentTurn && currentTurn.role === role) {
+      currentTurn.blocks.push(...parsedBlocks);
+    } else {
+      currentTurn = { role, timestamp, blocks: parsedBlocks };
+      turns.push(currentTurn);
+    }
+  }
+
+  return {
+    sessionId,
+    projectDir,
+    model,
+    version,
+    startTime,
+    turns,
+  };
+}

--- a/src/text-cleaning.ts
+++ b/src/text-cleaning.ts
@@ -1,0 +1,30 @@
+const SYSTEM_NOISE_PATTERNS: RegExp[] = [
+  /<task-notification>[\s\S]*?<\/task-notification>/g,
+  /<system-reminder>[\s\S]*?<\/system-reminder>/g,
+  /<command-message>[\s\S]*?<\/command-message>/g,
+  /<command-name>[\s\S]*?<\/command-name>/g,
+  /<command-args>[\s\S]*?<\/command-args>/g,
+  /<local-command-caveat>[\s\S]*?<\/local-command-caveat>/g,
+  /<local-command-stdout>[\s\S]*?<\/local-command-stdout>/g,
+  /Read the output file to retrieve the result:.*/g,
+];
+
+const SYSTEM_ONLY_PREFIXES: string[] = [
+  "Base directory for this skill:",
+  "This session is being continued from a previous conversation",
+];
+
+export function cleanUserText(text: string): string {
+  let cleaned = text;
+  for (const pattern of SYSTEM_NOISE_PATTERNS) {
+    cleaned = cleaned.replace(new RegExp(pattern.source, pattern.flags), "");
+  }
+  cleaned = cleaned.replace(/\n{3,}/g, "\n\n").trim();
+  return cleaned;
+}
+
+export function isSystemNoise(text: string): boolean {
+  const cleaned = cleanUserText(text);
+  if (!cleaned) return true;
+  return SYSTEM_ONLY_PREFIXES.some((prefix) => cleaned.startsWith(prefix));
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,12 @@
+export interface TextBlock { type: "text"; text: string; }
+export interface ThinkingBlock { type: "thinking"; text: string; }
+export interface ToolUseBlock { type: "tool_use"; name: string; input: Record<string, unknown>; id: string; }
+export interface ToolResultBlock { type: "tool_result"; content: string; meta: string | null; isError: boolean; toolUseId: string; }
+export interface SlashCommandBlock { type: "slash_command"; command: string; }
+export interface SessionContinuationBlock { type: "session_continuation"; text: string; }
+export type Block = TextBlock | ThinkingBlock | ToolUseBlock | ToolResultBlock | SlashCommandBlock | SessionContinuationBlock;
+export interface Turn { role: "user" | "assistant"; timestamp: string; blocks: Block[]; }
+export interface Conversation { sessionId: string | null; projectDir: string | null; model: string | null; version: string | null; startTime: string | null; turns: Turn[]; }
+export interface TocEntry { id: string; role: string; label: string; timestamp: string; preview: string; }
+export interface ConvertOptions { includeThinking?: boolean; includeTools?: boolean; }
+export interface ConvoDataEntry { role: string; timestamp: string; text: string[]; }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ES2022", "module": "ESNext", "moduleResolution": "bundler",
+    "lib": ["ES2022"], "strict": true, "noEmit": true, "esModuleInterop": true,
+    "resolveJsonModule": true, "declaration": true, "sourceMap": true,
+    "outDir": "dist", "rootDir": "src", "skipLibCheck": true
+  },
+  "include": ["src"], "exclude": ["node_modules", "dist"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,2 @@
+import { defineConfig } from "vitest/config";
+export default defineConfig({ test: { globals: true } });


### PR DESCRIPTION
## Summary
- Port `build_conversation()` from Python to TypeScript as `buildConversation()` in `src/parser.ts`
- Add project scaffolding: `package.json`, `tsconfig.json`, `vitest.config.ts`, shared `src/types.ts` and `src/text-cleaning.ts`
- Implement full JSONL parsing with metadata extraction, block classification (text, thinking, tool_use, tool_result, slash_command, session_continuation), tool result folding into assistant turns, and same-role turn merging

## Test plan
- [x] 27 unit tests covering all parsing paths in `src/parser.test.ts`
- [x] Basic user + assistant message parsing
- [x] Metadata extraction (sessionId, model, cwd, version, startTime)
- [x] String content vs array content handling
- [x] Tool use/result block extraction with string and array content
- [x] Tool result metadata separation (agentId, usage)
- [x] Error tool results (is_error: true)
- [x] Slash command and session continuation detection
- [x] System noise filtering
- [x] Tool result folding into assistant turns
- [x] Same-role turn merging
- [x] Malformed JSONL lines gracefully skipped
- [x] TypeScript compiles cleanly (`bun run check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)