### PR TITLE
Route all embedding through subprocess, remove main-thread model

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "convo-viewer",
       "dependencies": {
+        "@huggingface/transformers": "^3.8.1",
         "commander": "^12",
       },
       "devDependencies": {
@@ -17,6 +18,8 @@
     },
   },
   "packages": {
+    "@emnapi/runtime": ["@emnapi/runtime@1.9.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw=="],
+
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.24.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA=="],
 
     "@esbuild/android-arm": ["@esbuild/android-arm@0.24.2", "", { "os": "android", "cpu": "arm" }, "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q=="],
@@ -67,7 +70,83 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.24.2", "", { "os": "win32", "cpu": "x64" }, "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg=="],
 
+    "@huggingface/jinja": ["@huggingface/jinja@0.5.6", "", {}, "sha512-MyMWyLnjqo+KRJYSH7oWNbsOn5onuIvfXYPcc0WOGxU0eHUV7oAYUoQTl2BMdu7ml+ea/bu11UM+EshbeHwtIA=="],
+
+    "@huggingface/transformers": ["@huggingface/transformers@3.8.1", "", { "dependencies": { "@huggingface/jinja": "^0.5.3", "onnxruntime-node": "1.21.0", "onnxruntime-web": "1.22.0-dev.20250409-89f8206ba4", "sharp": "^0.34.1" } }, "sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA=="],
+
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
+    "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
+
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.4", "", {}, "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.0", "", {}, "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.0", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1", "@protobufjs/inquire": "^1.1.0" } }, "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.0", "", {}, "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.59.0", "", { "os": "android", "cpu": "arm" }, "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg=="],
 
@@ -141,6 +220,8 @@
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
+    "boolean": ["boolean@3.2.0", "", {}, "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="],
+
     "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
@@ -149,29 +230,77 @@
 
     "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
 
+    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
+
     "commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
 
+    "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
+
+    "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "detect-node": ["detect-node@2.1.0", "", {}, "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
     "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
+    "es6-error": ["es6-error@4.1.1", "", {}, "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="],
+
     "esbuild": ["esbuild@0.24.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.24.2", "@esbuild/android-arm": "0.24.2", "@esbuild/android-arm64": "0.24.2", "@esbuild/android-x64": "0.24.2", "@esbuild/darwin-arm64": "0.24.2", "@esbuild/darwin-x64": "0.24.2", "@esbuild/freebsd-arm64": "0.24.2", "@esbuild/freebsd-x64": "0.24.2", "@esbuild/linux-arm": "0.24.2", "@esbuild/linux-arm64": "0.24.2", "@esbuild/linux-ia32": "0.24.2", "@esbuild/linux-loong64": "0.24.2", "@esbuild/linux-mips64el": "0.24.2", "@esbuild/linux-ppc64": "0.24.2", "@esbuild/linux-riscv64": "0.24.2", "@esbuild/linux-s390x": "0.24.2", "@esbuild/linux-x64": "0.24.2", "@esbuild/netbsd-arm64": "0.24.2", "@esbuild/netbsd-x64": "0.24.2", "@esbuild/openbsd-arm64": "0.24.2", "@esbuild/openbsd-x64": "0.24.2", "@esbuild/sunos-x64": "0.24.2", "@esbuild/win32-arm64": "0.24.2", "@esbuild/win32-ia32": "0.24.2", "@esbuild/win32-x64": "0.24.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
+    "flatbuffers": ["flatbuffers@25.9.23", "", {}, "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ=="],
+
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "global-agent": ["global-agent@3.0.0", "", { "dependencies": { "boolean": "^3.0.1", "es6-error": "^4.1.1", "matcher": "^3.0.0", "roarr": "^2.15.3", "semver": "^7.3.2", "serialize-error": "^7.0.1" } }, "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q=="],
+
+    "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "guid-typescript": ["guid-typescript@1.0.9", "", {}, "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ=="],
+
+    "has-property-descriptors": ["has-property-descriptors@1.0.2", "", { "dependencies": { "es-define-property": "^1.0.0" } }, "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg=="],
+
+    "json-stringify-safe": ["json-stringify-safe@5.0.1", "", {}, "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="],
+
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
     "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "matcher": ["matcher@3.0.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0" } }, "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng=="],
+
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
+
+    "onnxruntime-common": ["onnxruntime-common@1.21.0", "", {}, "sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ=="],
+
+    "onnxruntime-node": ["onnxruntime-node@1.21.0", "", { "dependencies": { "global-agent": "^3.0.0", "onnxruntime-common": "1.21.0", "tar": "^7.0.1" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw=="],
+
+    "onnxruntime-web": ["onnxruntime-web@1.22.0-dev.20250409-89f8206ba4", "", { "dependencies": { "flatbuffers": "^25.1.24", "guid-typescript": "^1.0.9", "long": "^5.2.3", "onnxruntime-common": "1.22.0-dev.20250409-89f8206ba4", "platform": "^1.3.6", "protobufjs": "^7.2.4" } }, "sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ=="],
 
     "pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
 
@@ -179,17 +308,35 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
+    "platform": ["platform@1.3.6", "", {}, "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="],
+
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
+    "protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
+
+    "roarr": ["roarr@2.15.4", "", { "dependencies": { "boolean": "^3.0.1", "detect-node": "^2.0.4", "globalthis": "^1.0.1", "json-stringify-safe": "^5.0.1", "semver-compare": "^1.0.0", "sprintf-js": "^1.1.2" } }, "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A=="],
+
     "rollup": ["rollup@4.59.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.59.0", "@rollup/rollup-android-arm64": "4.59.0", "@rollup/rollup-darwin-arm64": "4.59.0", "@rollup/rollup-darwin-x64": "4.59.0", "@rollup/rollup-freebsd-arm64": "4.59.0", "@rollup/rollup-freebsd-x64": "4.59.0", "@rollup/rollup-linux-arm-gnueabihf": "4.59.0", "@rollup/rollup-linux-arm-musleabihf": "4.59.0", "@rollup/rollup-linux-arm64-gnu": "4.59.0", "@rollup/rollup-linux-arm64-musl": "4.59.0", "@rollup/rollup-linux-loong64-gnu": "4.59.0", "@rollup/rollup-linux-loong64-musl": "4.59.0", "@rollup/rollup-linux-ppc64-gnu": "4.59.0", "@rollup/rollup-linux-ppc64-musl": "4.59.0", "@rollup/rollup-linux-riscv64-gnu": "4.59.0", "@rollup/rollup-linux-riscv64-musl": "4.59.0", "@rollup/rollup-linux-s390x-gnu": "4.59.0", "@rollup/rollup-linux-x64-gnu": "4.59.0", "@rollup/rollup-linux-x64-musl": "4.59.0", "@rollup/rollup-openbsd-x64": "4.59.0", "@rollup/rollup-openharmony-arm64": "4.59.0", "@rollup/rollup-win32-arm64-msvc": "4.59.0", "@rollup/rollup-win32-ia32-msvc": "4.59.0", "@rollup/rollup-win32-x64-gnu": "4.59.0", "@rollup/rollup-win32-x64-msvc": "4.59.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg=="],
+
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "semver-compare": ["semver-compare@1.0.0", "", {}, "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="],
+
+    "serialize-error": ["serialize-error@7.0.1", "", { "dependencies": { "type-fest": "^0.13.1" } }, "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="],
+
+    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
+    "sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
+
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "tar": ["tar@7.5.11", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ=="],
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
@@ -200,6 +347,10 @@
     "tinyrainbow": ["tinyrainbow@1.2.0", "", {}, "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ=="],
 
     "tinyspy": ["tinyspy@3.0.2", "", {}, "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
@@ -212,6 +363,10 @@
     "vitest": ["vitest@2.1.9", "", { "dependencies": { "@vitest/expect": "2.1.9", "@vitest/mocker": "2.1.9", "@vitest/pretty-format": "^2.1.9", "@vitest/runner": "2.1.9", "@vitest/snapshot": "2.1.9", "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "debug": "^4.3.7", "expect-type": "^1.1.0", "magic-string": "^0.30.12", "pathe": "^1.1.2", "std-env": "^3.8.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.1", "tinypool": "^1.0.1", "tinyrainbow": "^1.2.0", "vite": "^5.0.0", "vite-node": "2.1.9", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "2.1.9", "@vitest/ui": "2.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q=="],
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
+
+    "onnxruntime-web/onnxruntime-common": ["onnxruntime-common@1.22.0-dev.20250409-89f8206ba4", "", {}, "sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ=="],
 
     "vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev": "bun run src/cli.ts"
   },
   "dependencies": {
+    "@huggingface/transformers": "^3.8.1",
     "commander": "^12"
   },
   "devDependencies": {

--- a/src/ask-page.ts
+++ b/src/ask-page.ts
@@ -12,7 +12,7 @@ export interface AskPageData {
     turns: Turn[];
     startTurnIndex: number;
   }>;
-  timing: { ftsMs: number; claudeMs: number; totalMs: number };
+  timing: { ftsMs: number; vectorMs?: number; claudeMs: number; totalMs: number };
   error?: string;
 }
 
@@ -278,8 +278,12 @@ export function buildAskResultsHtml(data: AskPageData): string {
 
   // Timing line
   const sessionCount = sources.length;
+  const timingParts: string[] = [];
+  if (timing.ftsMs) timingParts.push(`FTS ${timing.ftsMs}ms`);
+  if (timing.vectorMs) timingParts.push(`Vector ${timing.vectorMs}ms`);
+  if (timing.claudeMs) timingParts.push(`Claude ${timing.claudeMs}ms`);
   const timingHtml = `<div class="ask-timing">Searched ${sessionCount} session${sessionCount !== 1 ? "s" : ""} in ${timing.totalMs}ms`
-    + (timing.ftsMs ? ` <span class="timing-detail">(FTS ${timing.ftsMs}ms` + (timing.claudeMs ? `, Claude ${timing.claudeMs}ms` : "") + `)</span>` : "")
+    + (timingParts.length ? ` <span class="timing-detail">(${timingParts.join(", ")})</span>` : "")
     + `</div>`;
 
   // Render each source as a mini-conversation with the same turn styling as chat view

--- a/src/ask.test.ts
+++ b/src/ask.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { mergeFtsHits } from "./ask.js";
+
+// ---------------------------------------------------------------------------
+// Bug #7: FTS totalHits uses max instead of sum
+// ---------------------------------------------------------------------------
+
+describe("mergeFtsHits", () => {
+  it("accumulates totalHits across duplicate sessions (sum, not max)", () => {
+    const hits = [
+      { session_id: "s1", match_count: 3, best_rank: -5.0 },
+      { session_id: "s1", match_count: 2, best_rank: -3.0 },
+      { session_id: "s2", match_count: 1, best_rank: -4.0 },
+    ];
+
+    const result = mergeFtsHits(hits);
+
+    // totalHits should be 3 + 2 = 5 (sum), not max(3, 2) = 3
+    const s1 = result.get("s1")!;
+    expect(s1.totalHits).toBe(5);
+
+    // bestRank should be min(-5, -3) = -5 (lower is better)
+    expect(s1.bestRank).toBe(-5.0);
+
+    // s2 should be unaffected
+    const s2 = result.get("s2")!;
+    expect(s2.totalHits).toBe(1);
+  });
+
+  it("handles single occurrence correctly", () => {
+    const hits = [{ session_id: "s1", match_count: 7, best_rank: -2.0 }];
+    const result = mergeFtsHits(hits);
+    expect(result.get("s1")!.totalHits).toBe(7);
+    expect(result.get("s1")!.bestRank).toBe(-2.0);
+  });
+
+  it("handles empty input", () => {
+    const result = mergeFtsHits([]);
+    expect(result.size).toBe(0);
+  });
+
+  it("handles three-way merge for the same session", () => {
+    // Simulates: base FTS query + 2 Claude-extracted term queries all match the same session
+    const hits = [
+      { session_id: "s1", match_count: 2, best_rank: -4.0 },
+      { session_id: "s1", match_count: 1, best_rank: -2.0 },
+      { session_id: "s1", match_count: 3, best_rank: -6.0 },
+    ];
+
+    const result = mergeFtsHits(hits);
+    const s1 = result.get("s1")!;
+    expect(s1.totalHits).toBe(6); // 2 + 1 + 3
+    expect(s1.bestRank).toBe(-6.0); // min of all three
+  });
+});

--- a/src/ask.ts
+++ b/src/ask.ts
@@ -111,6 +111,27 @@ function turnToPlainText(turn: Turn): string {
 }
 
 // ---------------------------------------------------------------------------
+// FTS hit merging
+// ---------------------------------------------------------------------------
+
+/** Merge duplicate session hits from multiple FTS queries. Keeps best rank and sums hit counts. */
+export function mergeFtsHits(
+  sessionHits: Array<{ session_id: string; match_count: number; best_rank: number }>,
+): Map<string, { bestRank: number; totalHits: number }> {
+  const scores = new Map<string, { bestRank: number; totalHits: number }>();
+  for (const h of sessionHits) {
+    const existing = scores.get(h.session_id);
+    if (existing) {
+      if (h.best_rank < existing.bestRank) existing.bestRank = h.best_rank;
+      existing.totalHits += h.match_count;
+    } else {
+      scores.set(h.session_id, { bestRank: h.best_rank, totalHits: h.match_count });
+    }
+  }
+  return scores;
+}
+
+// ---------------------------------------------------------------------------
 // Main pipeline
 // ---------------------------------------------------------------------------
 
@@ -122,6 +143,7 @@ const CLAUDE_TIMEOUT_MS = 60_000;
 // ---------------------------------------------------------------------------
 
 async function extractSearchTerms(query: string): Promise<string[]> {
+  let proc: ReturnType<typeof Bun.spawn> | undefined;
   try {
     const home = process.env.HOME || os.homedir();
     const env: Record<string, string> = {};
@@ -136,7 +158,7 @@ async function extractSearchTerms(query: string): Promise<string[]> {
 
 Question: ${query}`;
 
-    const proc = Bun.spawn([claudeBin, "-p", "--model", "sonnet"], {
+    proc = Bun.spawn([claudeBin, "-p", "--model", "sonnet"], {
       stdin: "pipe",
       stdout: "pipe",
       stderr: "pipe",
@@ -160,6 +182,7 @@ Question: ${query}`;
       .map((l) => l.trim().replace(/^[-*\d.]+\s*/, ""))
       .filter((l) => l.length > 1 && l.length < 60);
   } catch {
+    proc?.kill();
     return [];
   }
 }
@@ -299,20 +322,8 @@ export async function askQuestion(
   const RRF_K = 60;
 
   // Build FTS session ranking (deduplicated, sorted by score)
-  const ftsSessionScores = new Map<string, { bestRank: number; totalHits: number }>();
-  for (const h of sessionHits) {
-    if (isExcluded(h.session_id)) continue;
-    const existing = ftsSessionScores.get(h.session_id);
-    if (existing) {
-      if (h.best_rank < existing.bestRank) existing.bestRank = h.best_rank;
-      if (h.match_count > existing.totalHits) existing.totalHits = h.match_count;
-    } else {
-      ftsSessionScores.set(h.session_id, {
-        bestRank: h.best_rank,
-        totalHits: h.match_count,
-      });
-    }
-  }
+  const filteredHits = sessionHits.filter((h) => !isExcluded(h.session_id));
+  const ftsSessionScores = mergeFtsHits(filteredHits);
   // Sort FTS sessions by rank (lower = better) with hit count tiebreak
   const ftsRanked = [...ftsSessionScores.entries()]
     .sort((a, b) => {
@@ -490,6 +501,7 @@ Use markdown formatting in your answer.`;
   const tClaudeStart = performance.now();
 
   if (sources.length > 0) {
+    let proc: ReturnType<typeof Bun.spawn> | undefined;
     try {
       // Unset CLAUDECODE to avoid nested session detection, ensure HOME/PATH
       const home = process.env.HOME || os.homedir();
@@ -500,7 +512,7 @@ Use markdown formatting in your answer.`;
       env.HOME = home;
       if (!env.PATH) env.PATH = `/usr/local/bin:/usr/bin:/bin:${home}/.local/bin`;
       const claudeBin = `${home}/.local/bin/claude`;
-      const proc = Bun.spawn([claudeBin, "-p", "--model", "haiku"], {
+      proc = Bun.spawn([claudeBin, "-p", "--model", "haiku"], {
         stdin: "pipe",
         stdout: "pipe",
         stderr: "pipe",
@@ -533,6 +545,7 @@ Use markdown formatting in your answer.`;
         if (!answer) answer = "";
       }
     } catch (e) {
+      proc?.kill();
       claudeError = e instanceof Error ? e.message : String(e);
     }
   } else {

--- a/src/ask.ts
+++ b/src/ask.ts
@@ -3,6 +3,7 @@ import * as os from "node:os";
 import type { ConvoDb } from "./db.js";
 import { IncrementalParser } from "./incremental-parser.js";
 import type { Turn } from "./types.js";
+import type { EmbeddingEngine, VectorIndex } from "./embeddings.js";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -21,7 +22,7 @@ export interface AskResult {
   query: string;
   answer: string;
   sources: AskSource[];
-  timing: { ftsMs: number; claudeMs: number; totalMs: number };
+  timing: { ftsMs: number; vectorMs: number; claudeMs: number; totalMs: number };
   error?: string;
 }
 
@@ -205,7 +206,12 @@ function searchMetadata(
 export async function askQuestion(
   db: ConvoDb,
   query: string,
-  options?: { maxSources?: number; contextTurns?: number },
+  options?: {
+    maxSources?: number;
+    contextTurns?: number;
+    vectorIndex?: VectorIndex;
+    embeddingEngine?: EmbeddingEngine;
+  },
 ): Promise<AskResult> {
   const t0 = performance.now();
   const maxSources = options?.maxSources ?? 6;
@@ -264,65 +270,93 @@ export async function askQuestion(
   const tFts = performance.now();
 
   // ------------------------------------------------------------------
-  // Merge & deduplicate with unified scoring
+  // Vector search (parallel to FTS, gracefully skipped if unavailable)
   // ------------------------------------------------------------------
-  // Combine all signals into a single score per session.
-  // FTS rank (negative, lower = better) is primary; metadata match adds a boost;
-  // match count breaks ties.
-  const metadataSet = new Set(metadataIds);
-  const sessionScores = new Map<string, { bestRank: number; totalHits: number; metadataBoost: boolean }>();
+  let vectorSessionRanking: Array<{
+    sessionId: string;
+    bestScore: number;
+    bestTurnIndex: number;
+    matchCount: number;
+  }> = [];
+  let vectorMs = 0;
 
+  if (options?.vectorIndex && options?.embeddingEngine?.isReady() && options.vectorIndex.count > 0) {
+    try {
+      const tVec0 = performance.now();
+      const queryVec = await options.embeddingEngine.embedQuery(query);
+      vectorSessionRanking = options.vectorIndex.searchSessions(queryVec, maxSources * 4);
+      vectorMs = Math.round(performance.now() - tVec0);
+      console.log(`[ask] Vector search: ${vectorSessionRanking.length} sessions in ${vectorMs}ms`);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.error(`[ask] Vector search error: ${msg}`);
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // RRF merge: combine FTS, vector, and metadata signals
+  // ------------------------------------------------------------------
+  const RRF_K = 60;
+
+  // Build FTS session ranking (deduplicated, sorted by score)
+  const ftsSessionScores = new Map<string, { bestRank: number; totalHits: number }>();
   for (const h of sessionHits) {
     if (isExcluded(h.session_id)) continue;
-    const existing = sessionScores.get(h.session_id);
+    const existing = ftsSessionScores.get(h.session_id);
     if (existing) {
       if (h.best_rank < existing.bestRank) existing.bestRank = h.best_rank;
-      // Use max hit count across queries, not sum — avoids double-counting
-      // when the same session matches multiple extracted terms
       if (h.match_count > existing.totalHits) existing.totalHits = h.match_count;
     } else {
-      sessionScores.set(h.session_id, {
+      ftsSessionScores.set(h.session_id, {
         bestRank: h.best_rank,
         totalHits: h.match_count,
-        metadataBoost: metadataSet.has(h.session_id),
       });
     }
   }
-  // Add metadata-only sessions (no FTS hits) with a neutral rank
-  for (const id of metadataIds) {
-    if (!sessionScores.has(id) && !isExcluded(id)) {
-      sessionScores.set(id, { bestRank: 0, totalHits: 0, metadataBoost: true });
-    }
-  }
-
-  // Two-pass selection: first guarantee metadata matches get slots (they matched
-  // project name/title which is high-signal), then fill remaining slots by score.
-  // Score combines FTS rank with hit count: more hits = more relevant content.
-  function computeScore(s: { bestRank: number; totalHits: number; metadataBoost: boolean }): number {
-    const hitsBoost = s.totalHits > 1 ? Math.log2(s.totalHits) * 1.5 : 0;
-    return s.bestRank - hitsBoost;
-  }
-
-  const metadataEntries = [...sessionScores.entries()]
-    .filter(([, s]) => s.metadataBoost)
-    .sort((a, b) => computeScore(a[1]) - computeScore(b[1]));
-  const ftsEntries = [...sessionScores.entries()]
-    .filter(([, s]) => !s.metadataBoost)
-    .sort((a, b) => computeScore(a[1]) - computeScore(b[1]));
-
-  // Reserve up to half the slots for metadata, fill rest with FTS
-  const metadataSlots = Math.min(metadataEntries.length, Math.ceil(maxSources / 2));
-  const ftsSlots = maxSources - metadataSlots;
-
-  const selectedMeta = metadataEntries.slice(0, metadataSlots).map(([id]) => id);
-  const selectedFts = ftsEntries
-    .filter(([id]) => !selectedMeta.includes(id))
-    .slice(0, ftsSlots)
+  // Sort FTS sessions by rank (lower = better) with hit count tiebreak
+  const ftsRanked = [...ftsSessionScores.entries()]
+    .sort((a, b) => {
+      const ra = a[1].bestRank - (a[1].totalHits > 1 ? Math.log2(a[1].totalHits) * 1.5 : 0);
+      const rb = b[1].bestRank - (b[1].totalHits > 1 ? Math.log2(b[1].totalHits) * 1.5 : 0);
+      return ra - rb;
+    })
     .map(([id]) => id);
 
-  const finalSessionIds = [...selectedMeta, ...selectedFts];
+  // Build vector session ranking (already sorted by bestScore desc)
+  // Preserve bestTurnIndex for use in context loading
+  const vectorTurnHints = new Map<string, number>();
+  const vectorRanked: string[] = [];
+  for (const v of vectorSessionRanking) {
+    if (isExcluded(v.sessionId)) continue;
+    vectorRanked.push(v.sessionId);
+    vectorTurnHints.set(v.sessionId, v.bestTurnIndex);
+  }
 
-  console.log(`[ask] Selected ${finalSessionIds.length} sessions: ${metadataSlots} metadata + ${selectedFts.length} FTS`);
+  // Metadata ranking
+  const metadataRanked = metadataIds.filter((id) => !isExcluded(id));
+
+  // Compute RRF scores
+  const rrfScores = new Map<string, number>();
+  const allSessionIds = new Set([...ftsRanked, ...vectorRanked, ...metadataRanked]);
+
+  for (const id of allSessionIds) {
+    let score = 0;
+    const ftsPos = ftsRanked.indexOf(id);
+    if (ftsPos >= 0) score += 1 / (RRF_K + ftsPos + 1);
+    const vecPos = vectorRanked.indexOf(id);
+    if (vecPos >= 0) score += 1 / (RRF_K + vecPos + 1);
+    const metaPos = metadataRanked.indexOf(id);
+    if (metaPos >= 0) score += 1 / (RRF_K + metaPos + 1);
+    rrfScores.set(id, score);
+  }
+
+  // Select top N sessions by RRF score
+  const finalSessionIds = [...rrfScores.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, maxSources)
+    .map(([id]) => id);
+
+  console.log(`[ask] RRF selected ${finalSessionIds.length} sessions (FTS:${ftsRanked.length} Vec:${vectorRanked.length} Meta:${metadataRanked.length})`);
 
   // ------------------------------------------------------------------
   // 3. Load turn context
@@ -361,7 +395,15 @@ export async function askQuestion(
     ]);
     const keywords = [...allTerms];
     const matchingIndices: number[] = [];
+
+    // Prioritize the vector search's best turn if available
+    const vecHint = vectorTurnHints.get(sessionId);
+    if (vecHint !== undefined && vecHint >= 0 && vecHint < allTurns.length) {
+      matchingIndices.push(vecHint);
+    }
+
     for (let i = 0; i < allTurns.length; i++) {
+      if (i === vecHint) continue; // already added
       const text = turnToPlainText(allTurns[i]).toLowerCase();
       if (keywords.some((kw) => text.includes(kw))) {
         matchingIndices.push(i);
@@ -508,6 +550,7 @@ Use markdown formatting in your answer.`;
     sources,
     timing: {
       ftsMs: Math.round(tFts - t0),
+      vectorMs,
       claudeMs: Math.round(tEnd - tClaudeStart),
       totalMs: Math.round(tEnd - t0),
     },

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -687,4 +687,53 @@ describe("ConvoDb", () => {
       expect(session!.project).toBe("/my/project");
     });
   });
+
+  // -----------------------------------------------------------------------
+  // Bug #5: FTS ghost entries via broken contentless delete
+  // -----------------------------------------------------------------------
+
+  describe("FTS ghost entries", () => {
+    it("removeFtsIndex does not leave ghost tokens in FTS inverted index", () => {
+      db.upsertSession({ id: "ghost-test" });
+      db.indexSession("ghost-test", [{ role: "user", text: "unique_ghost_xylophone" }], 100);
+
+      // Verify it's searchable via the JOIN path
+      expect(db.searchSessions("unique_ghost_xylophone", 10).length).toBe(1);
+
+      // Remove the FTS index
+      db.removeFtsIndex("ghost-test");
+
+      // Query FTS directly (bypass fts_map JOIN) — ghost tokens would still match
+      const ghosts = db.db.query(
+        "SELECT rowid FROM conversation_fts WHERE conversation_fts MATCH 'unique_ghost_xylophone'",
+      ).all();
+
+      // Ghost entries should be gone from the FTS inverted index
+      expect(ghosts.length).toBe(0);
+    });
+
+    it("re-indexing does not accumulate ghost tokens", () => {
+      db.upsertSession({ id: "reindex-ghost" });
+
+      // Index, then re-index with different text 3 times
+      db.indexSession("reindex-ghost", [{ role: "user", text: "phantom_alpha" }], 100);
+      db.indexSession("reindex-ghost", [{ role: "user", text: "phantom_beta" }], 200);
+      db.indexSession("reindex-ghost", [{ role: "user", text: "phantom_gamma" }], 300);
+
+      // Only "phantom_gamma" should exist in the FTS inverted index
+      const alphaGhosts = db.db.query(
+        "SELECT rowid FROM conversation_fts WHERE conversation_fts MATCH 'phantom_alpha'",
+      ).all();
+      const betaGhosts = db.db.query(
+        "SELECT rowid FROM conversation_fts WHERE conversation_fts MATCH 'phantom_beta'",
+      ).all();
+      const gammaHits = db.db.query(
+        "SELECT rowid FROM conversation_fts WHERE conversation_fts MATCH 'phantom_gamma'",
+      ).all();
+
+      expect(alphaGhosts.length).toBe(0);
+      expect(betaGhosts.length).toBe(0);
+      expect(gammaHits.length).toBe(1);
+    });
+  });
 });

--- a/src/db.ts
+++ b/src/db.ts
@@ -149,6 +149,7 @@ CREATE TABLE IF NOT EXISTS fts_status (
 CREATE VIRTUAL TABLE IF NOT EXISTS conversation_fts USING fts5(
   text,
   content='',
+  contentless_delete=1,
   content_rowid='id'
 );
 
@@ -596,7 +597,7 @@ export class ConvoDb {
     const rows = this.db.query("SELECT id FROM fts_map WHERE session_id = ?").all(sessionId) as { id: number }[];
     if (rows.length > 0) {
       for (const row of rows) {
-        this.db.run("INSERT INTO conversation_fts(conversation_fts, rowid, text) VALUES('delete', ?, '')", [row.id]);
+        this.db.run("DELETE FROM conversation_fts WHERE rowid = ?", [row.id]);
       }
       this.db.run("DELETE FROM fts_map WHERE session_id = ?", [sessionId]);
     }
@@ -823,6 +824,16 @@ export function openDb(dbPath?: string): ConvoDb {
   try { db.exec("ALTER TABLE sessions ADD COLUMN last_modified INTEGER"); } catch {}
   try { db.exec("ALTER TABLE sessions ADD COLUMN file_size INTEGER"); } catch {}
   try { db.exec("ALTER TABLE fts_status ADD COLUMN file_mtime INTEGER NOT NULL DEFAULT 0"); } catch {}
+
+  // Migrate FTS to contentless_delete=1 if needed (fixes ghost entry bug)
+  try {
+    const ftsInfo = db.query("SELECT sql FROM sqlite_master WHERE name = 'conversation_fts'").get() as { sql: string } | null;
+    if (ftsInfo?.sql && !ftsInfo.sql.includes("contentless_delete")) {
+      db.exec("DROP TABLE IF EXISTS conversation_fts");
+      db.exec("CREATE VIRTUAL TABLE conversation_fts USING fts5(text, content='', contentless_delete=1, content_rowid='id')");
+      db.exec("DELETE FROM fts_status"); // Force re-index on next backfill
+    }
+  } catch {}
 
   return new ConvoDb(db);
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -156,6 +156,28 @@ CREATE TABLE IF NOT EXISTS settings (
   key TEXT PRIMARY KEY,
   value TEXT NOT NULL
 );
+
+-- Embedding vectors stored as BLOBs (256 x float32 = 1024 bytes each)
+CREATE TABLE IF NOT EXISTS turn_embeddings (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id TEXT NOT NULL,
+  turn_index INTEGER NOT NULL,
+  role TEXT NOT NULL DEFAULT '',
+  text_hash TEXT NOT NULL,
+  embedding BLOB NOT NULL,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+  UNIQUE(session_id, turn_index)
+);
+CREATE INDEX IF NOT EXISTS idx_turn_emb_session ON turn_embeddings(session_id);
+
+-- Track embedding indexing status per session (mirrors fts_status pattern)
+CREATE TABLE IF NOT EXISTS embedding_status (
+  session_id TEXT PRIMARY KEY,
+  indexed_at INTEGER NOT NULL DEFAULT (unixepoch()),
+  turn_count INTEGER NOT NULL DEFAULT 0,
+  file_mtime INTEGER NOT NULL DEFAULT 0,
+  model_name TEXT NOT NULL DEFAULT 'snowflake-arctic-embed-m-v2.0'
+);
 `;
 
 // ---------------------------------------------------------------------------
@@ -657,6 +679,101 @@ export class ConvoDb {
   /** Set project path patterns excluded from AI search */
   setSearchExcludedProjects(patterns: string[]): void {
     this.setSetting("search_excluded_projects", patterns.join("\n"));
+  }
+
+  // ---- Embeddings ---------------------------------------------------------
+
+  /** Check if a session needs embedding (re)indexing based on file mtime. */
+  embeddingNeedsIndexing(sessionId: string, fileMtime: number): boolean {
+    const row = this.db.query("SELECT file_mtime FROM embedding_status WHERE session_id = ?").get(sessionId) as { file_mtime: number } | null;
+    if (!row) return true;
+    return fileMtime > row.file_mtime;
+  }
+
+  /** Store embeddings for a session's turns. Replaces any existing. */
+  storeEmbeddings(
+    sessionId: string,
+    entries: Array<{
+      turnIndex: number;
+      role: string;
+      textHash: string;
+      embedding: Float32Array;
+    }>,
+    fileMtime: number,
+  ): void {
+    this.db.exec("BEGIN");
+    try {
+      // Remove old embeddings for this session
+      this.db.run("DELETE FROM turn_embeddings WHERE session_id = ?", [sessionId]);
+
+      const insert = this.db.prepare(
+        "INSERT INTO turn_embeddings (session_id, turn_index, role, text_hash, embedding) VALUES (?, ?, ?, ?, ?)",
+      );
+      for (const entry of entries) {
+        const blob = Buffer.from(entry.embedding.buffer, entry.embedding.byteOffset, entry.embedding.byteLength);
+        insert.run(sessionId, entry.turnIndex, entry.role, entry.textHash, blob);
+      }
+
+      this.db.run(
+        "INSERT OR REPLACE INTO embedding_status (session_id, indexed_at, turn_count, file_mtime) VALUES (?, unixepoch(), ?, ?)",
+        [sessionId, entries.length, fileMtime],
+      );
+
+      this.db.exec("COMMIT");
+    } catch (e) {
+      this.db.exec("ROLLBACK");
+      throw e;
+    }
+  }
+
+  /** Remove all embeddings for a session. */
+  removeEmbeddings(sessionId: string): void {
+    this.db.run("DELETE FROM turn_embeddings WHERE session_id = ?", [sessionId]);
+    this.db.run("DELETE FROM embedding_status WHERE session_id = ?", [sessionId]);
+  }
+
+  /** Load all embeddings into memory. Returns arrays for VectorIndex construction. */
+  loadAllEmbeddings(): {
+    sessionIds: string[];
+    turnIndices: number[];
+    roles: string[];
+    embeddings: Float32Array[];
+  } {
+    const rows = this.db.query(
+      "SELECT session_id, turn_index, role, embedding FROM turn_embeddings ORDER BY session_id, turn_index",
+    ).all() as Array<{
+      session_id: string;
+      turn_index: number;
+      role: string;
+      embedding: Buffer;
+    }>;
+
+    const sessionIds: string[] = [];
+    const turnIndices: number[] = [];
+    const roles: string[] = [];
+    const embeddings: Float32Array[] = [];
+
+    const EXPECTED_BLOB_SIZE = 256 * 4; // 256 dims × 4 bytes per float32
+    for (const row of rows) {
+      const buf = row.embedding;
+      if (buf.byteLength !== EXPECTED_BLOB_SIZE) {
+        console.warn(`[db] Skipping corrupt embedding: session=${row.session_id} turn=${row.turn_index} (${buf.byteLength} bytes, expected ${EXPECTED_BLOB_SIZE})`);
+        continue;
+      }
+      sessionIds.push(row.session_id);
+      turnIndices.push(row.turn_index);
+      roles.push(row.role);
+      const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+      embeddings.push(new Float32Array(ab));
+    }
+
+    return { sessionIds, turnIndices, roles, embeddings };
+  }
+
+  /** Get count of sessions with embeddings. */
+  embeddingIndexedCount(): number {
+    const row = this.db.query("SELECT COUNT(*) as n FROM embedding_status").get() as { n: number };
+    return row.n;
   }
 
   // ---- Lifecycle ----------------------------------------------------------

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -240,8 +240,9 @@ const FTS_INDEX_LIMIT = 100 * 1024 * 1024;
 /**
  * Background FTS indexing: index conversation text for full-text search.
  * Processes sessions that haven't been indexed yet, in batches.
+ * Optional onComplete callback fires when all sessions are indexed.
  */
-export function backfillFtsIndex(db: ConvoDb): void {
+export function backfillFtsIndex(db: ConvoDb, onComplete?: () => void): void {
   const sessions = db.listSessions({}) as Array<{
     id: string;
     jsonl_path?: string | null;
@@ -264,7 +265,10 @@ export function backfillFtsIndex(db: ConvoDb): void {
     }
   }
 
-  if (needsIndexing.length === 0) return;
+  if (needsIndexing.length === 0) {
+    onComplete?.();
+    return;
+  }
 
   console.log(`FTS indexing ${needsIndexing.length} sessions...`);
   let i = 0;
@@ -299,6 +303,7 @@ export function backfillFtsIndex(db: ConvoDb): void {
       setTimeout(batch, 10); // yield to event loop between batches
     } else {
       console.log(`FTS: ${indexed} sessions indexed`);
+      onComplete?.();
     }
   };
 

--- a/src/embedding-worker.ts
+++ b/src/embedding-worker.ts
@@ -1,0 +1,106 @@
+/**
+ * Embedding subprocess — runs ONNX inference in a separate process so the
+ * HTTP server event loop is never blocked.
+ *
+ * Spawned by EmbeddingEngine via Bun.spawn(). Communicates over stdin/stdout
+ * using newline-delimited JSON:
+ *
+ *   stdin  (parent → child): { id: number, texts: string[] }
+ *   stdout (child → parent): { id: number, embeddings: number[][] }
+ *                          | { id: number, error: string }
+ *                          | { type: "ready" }
+ *                          | { type: "status", message: string }
+ */
+
+const MODEL_NAME = "Snowflake/snowflake-arctic-embed-m-v2.0";
+const EMBEDDING_DIMS = 256;
+
+let extractor: any = null;
+
+function truncateAndNormalize(vec: number[]): number[] {
+  const out = new Array(EMBEDDING_DIMS);
+  let norm = 0;
+  for (let i = 0; i < EMBEDDING_DIMS; i++) {
+    const v = i < vec.length ? vec[i] : 0;
+    out[i] = v;
+    norm += v * v;
+  }
+  norm = Math.sqrt(norm);
+  if (norm > 0) {
+    for (let i = 0; i < EMBEDDING_DIMS; i++) {
+      out[i] /= norm;
+    }
+  }
+  return out;
+}
+
+function send(obj: unknown) {
+  process.stdout.write(JSON.stringify(obj) + "\n");
+}
+
+async function init() {
+  try {
+    send({ type: "status", message: "Loading model..." });
+    const { pipeline, env } = await import("@huggingface/transformers");
+    try {
+      extractor = await pipeline("feature-extraction", MODEL_NAME, { dtype: "q8" });
+    } catch {
+      if (env.backends?.onnx?.wasm) {
+        env.backends.onnx.wasm.numThreads = 1;
+      }
+      extractor = await pipeline("feature-extraction", MODEL_NAME, {
+        dtype: "q8",
+        device: "wasm",
+      });
+    }
+    send({ type: "ready" });
+  } catch (err) {
+    send({ type: "status", message: `Failed to load model: ${err}` });
+    process.exit(1);
+  }
+}
+
+async function handleRequest(line: string) {
+  let parsed: { id: number; texts: string[] };
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return; // ignore malformed input
+  }
+
+  const { id, texts } = parsed;
+  if (!extractor) {
+    send({ id, error: "Model not loaded" });
+    return;
+  }
+
+  try {
+    const truncated = texts.map((t: string) => (t.length > 2000 ? t.slice(0, 2000) : t));
+    const output = await extractor(truncated, { pooling: "cls", normalize: true });
+    const fullVectors = output.tolist();
+    const embeddings = fullVectors.map((vec: number[]) => truncateAndNormalize(vec));
+    send({ id, embeddings });
+  } catch (err) {
+    send({ id, error: String(err) });
+  }
+}
+
+// Read newline-delimited JSON from stdin
+let buffer = "";
+process.stdin.setEncoding("utf-8");
+process.stdin.on("data", (chunk: string) => {
+  buffer += chunk;
+  const lines = buffer.split("\n");
+  buffer = lines.pop() || ""; // keep incomplete line in buffer
+  for (const line of lines) {
+    if (line.trim()) {
+      handleRequest(line);
+    }
+  }
+});
+
+process.stdin.on("end", () => {
+  process.exit(0);
+});
+
+init();

--- a/src/embeddings.test.ts
+++ b/src/embeddings.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from "vitest";
+import { VectorIndex, EMBEDDING_DIMS, truncateAndNormalize } from "./embeddings.js";
+import type { EmbeddingDb } from "./embeddings.js";
+
+// Helper to create a mock EmbeddingDb
+function mockDb(data: {
+  sessionIds: string[];
+  turnIndices: number[];
+  roles: string[];
+  embeddings: Float32Array[];
+}): EmbeddingDb {
+  return { loadAllEmbeddings: () => data };
+}
+
+// Helper to create a normalized vector with given leading components
+function makeVec(...values: number[]): Float32Array {
+  const vec = new Float32Array(EMBEDDING_DIMS);
+  for (let i = 0; i < Math.min(values.length, EMBEDDING_DIMS); i++) {
+    vec[i] = values[i];
+  }
+  let norm = 0;
+  for (let i = 0; i < EMBEDDING_DIMS; i++) norm += vec[i] * vec[i];
+  norm = Math.sqrt(norm);
+  if (norm > 0) for (let i = 0; i < EMBEDDING_DIMS; i++) vec[i] /= norm;
+  return vec;
+}
+
+// ---------------------------------------------------------------------------
+// Bug #1: truncateAndNormalize NaN propagation from short vectors
+// ---------------------------------------------------------------------------
+
+describe("truncateAndNormalize", () => {
+  it("handles vectors shorter than EMBEDDING_DIMS without producing NaN", () => {
+    const shortVec = [0.5, 0.3, 0.1]; // only 3 elements, 256 expected
+    const result = truncateAndNormalize(shortVec);
+
+    expect(result.length).toBe(EMBEDDING_DIMS);
+    for (let i = 0; i < result.length; i++) {
+      expect(Number.isNaN(result[i])).toBe(false);
+    }
+    // First 3 should be non-zero (normalized), rest should be 0
+    expect(result[0]).not.toBe(0);
+    expect(result[3]).toBe(0);
+    expect(result[255]).toBe(0);
+  });
+
+  it("handles empty vector without producing NaN", () => {
+    const result = truncateAndNormalize([]);
+    expect(result.length).toBe(EMBEDDING_DIMS);
+    for (let i = 0; i < result.length; i++) {
+      expect(Number.isNaN(result[i])).toBe(false);
+    }
+  });
+
+  it("handles full-length vector correctly", () => {
+    const fullVec = new Array(EMBEDDING_DIMS).fill(0);
+    fullVec[0] = 1.0;
+    const result = truncateAndNormalize(fullVec);
+    expect(result[0]).toBeCloseTo(1.0);
+    expect(Number.isNaN(result[0])).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bug #4: Score comment says 0-1 but cosine can be negative
+// ---------------------------------------------------------------------------
+
+describe("VectorIndex.search", () => {
+  it("can return negative cosine similarity scores", () => {
+    const v1 = makeVec(1, 0);
+    const v2 = makeVec(-1, 0);
+    const index = VectorIndex.fromDb(
+      mockDb({
+        sessionIds: ["pos", "neg"],
+        turnIndices: [0, 0],
+        roles: ["user", "user"],
+        embeddings: [v1, v2],
+      }),
+    );
+
+    const query = makeVec(1, 0);
+    const results = index.search(query, 10);
+    const negResult = results.find((r) => r.sessionId === "neg");
+    expect(negResult).toBeDefined();
+    expect(negResult!.score).toBeLessThan(0);
+  });
+
+  it("returns valid (non-NaN) scores for all results", () => {
+    const v1 = makeVec(1, 0);
+    const v2 = makeVec(0, 1);
+    const index = VectorIndex.fromDb(
+      mockDb({
+        sessionIds: ["s1", "s2"],
+        turnIndices: [0, 0],
+        roles: ["user", "user"],
+        embeddings: [v1, v2],
+      }),
+    );
+
+    const query = makeVec(1, 0);
+    const results = index.search(query, 10);
+    for (const r of results) {
+      expect(Number.isNaN(r.score)).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bug #3: Session starvation in searchSessions
+// ---------------------------------------------------------------------------
+
+describe("VectorIndex.searchSessions", () => {
+  it("does not starve sessions when one has many more turns", () => {
+    const sessionIds: string[] = [];
+    const turnIndices: number[] = [];
+    const roles: string[] = [];
+    const embeddings: Float32Array[] = [];
+
+    // "big" session: 200 turns, all somewhat aligned with query
+    for (let i = 0; i < 200; i++) {
+      sessionIds.push("big");
+      turnIndices.push(i);
+      roles.push("user");
+      embeddings.push(makeVec(0.9, 0.1 * (i % 5)));
+    }
+
+    // "small" session: 2 turns, well-aligned with query
+    for (let i = 0; i < 2; i++) {
+      sessionIds.push("small");
+      turnIndices.push(i);
+      roles.push("user");
+      embeddings.push(makeVec(0.85, 0.15));
+    }
+
+    const index = VectorIndex.fromDb(
+      mockDb({ sessionIds, turnIndices, roles, embeddings }),
+    );
+
+    // topK=2 means searchSessions should return at most 2 sessions
+    // With the old code: search(query, 2*5=10) returns top 10 turns,
+    // which are all from "big" → "small" is starved out
+    const query = makeVec(1, 0);
+    const results = index.searchSessions(query, 2);
+
+    const ids = results.map((r) => r.sessionId);
+    expect(ids).toContain("big");
+    expect(ids).toContain("small");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bug #2: Unhandled promise rejection in EmbeddingEngine constructor
+// ---------------------------------------------------------------------------
+
+describe("EmbeddingEngine", () => {
+  it("does not produce unhandled rejection when GLOSS_NO_EMBEDDINGS is set", async () => {
+    const original = process.env.GLOSS_NO_EMBEDDINGS;
+    process.env.GLOSS_NO_EMBEDDINGS = "1";
+
+    let unhandled = false;
+    const handler = () => {
+      unhandled = true;
+    };
+    process.on("unhandledRejection", handler);
+
+    try {
+      // Dynamic import to avoid model loading in other tests
+      const { EmbeddingEngine } = await import("./embeddings.js");
+      const engine = new EmbeddingEngine();
+      expect(engine.hasFailed()).toBe(true);
+      expect(engine.isReady()).toBe(false);
+
+      // Give event loop time to surface any unhandled rejection
+      await new Promise((r) => setTimeout(r, 200));
+
+      expect(unhandled).toBe(false);
+    } finally {
+      process.off("unhandledRejection", handler);
+      if (original === undefined) delete process.env.GLOSS_NO_EMBEDDINGS;
+      else process.env.GLOSS_NO_EMBEDDINGS = original;
+    }
+  });
+});

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -34,6 +34,8 @@ export class EmbeddingEngine {
       this.resolveReady = resolve;
       this.rejectReady = reject;
     });
+    // Prevent unhandled rejection crash when no one calls waitReady()
+    this.readyPromise.catch(() => {});
 
     // Allow users to opt out on constrained machines
     if (process.env.GLOSS_NO_EMBEDDINGS) {
@@ -144,13 +146,14 @@ export class EmbeddingEngine {
 // Vector math helpers
 // ---------------------------------------------------------------------------
 
-/** Truncate to EMBEDDING_DIMS and L2-normalize. */
-function truncateAndNormalize(vec: number[]): Float32Array {
+/** Truncate to EMBEDDING_DIMS and L2-normalize. @internal exported for testing. */
+export function truncateAndNormalize(vec: number[]): Float32Array {
   const out = new Float32Array(EMBEDDING_DIMS);
   let norm = 0;
   for (let i = 0; i < EMBEDDING_DIMS; i++) {
-    out[i] = vec[i];
-    norm += vec[i] * vec[i];
+    const v = i < vec.length ? vec[i] : 0;
+    out[i] = v;
+    norm += v * v;
   }
   norm = Math.sqrt(norm);
   if (norm > 0) {
@@ -178,7 +181,7 @@ export interface VectorSearchResult {
   sessionId: string;
   turnIndex: number;
   role: string;
-  score: number; // cosine similarity, 0-1
+  score: number; // cosine similarity, -1..1 (vectors are L2-normalized, so dot = cosine)
 }
 
 // ---------------------------------------------------------------------------
@@ -327,6 +330,7 @@ export class VectorIndex {
   /**
    * Aggregate turn-level results to session-level.
    * Returns sessions ranked by their best turn's score.
+   * Aggregates during the O(N) scan to avoid session starvation.
    */
   searchSessions(
     queryVector: Float32Array,
@@ -337,27 +341,32 @@ export class VectorIndex {
     bestTurnIndex: number;
     matchCount: number;
   }> {
-    // Get more turn-level results to ensure good session coverage
-    const turnResults = this.search(queryVector, topK * 5);
+    if (this._count === 0) return [];
 
-    // Aggregate by session
+    // Aggregate per-session during the full scan — guarantees every session
+    // is considered, regardless of how many turns any single session has.
     const sessionMap = new Map<
       string,
       { bestScore: number; bestTurnIndex: number; matchCount: number }
     >();
 
-    for (const r of turnResults) {
-      const existing = sessionMap.get(r.sessionId);
+    for (let i = 0; i < this._count; i++) {
+      const offset = i * EMBEDDING_DIMS;
+      const vec = this.vectors.subarray(offset, offset + EMBEDDING_DIMS);
+      const score = dot(queryVector, vec);
+
+      const sessionId = this.sessionIds[i];
+      const existing = sessionMap.get(sessionId);
       if (existing) {
         existing.matchCount++;
-        if (r.score > existing.bestScore) {
-          existing.bestScore = r.score;
-          existing.bestTurnIndex = r.turnIndex;
+        if (score > existing.bestScore) {
+          existing.bestScore = score;
+          existing.bestTurnIndex = this.turnIndices[i];
         }
       } else {
-        sessionMap.set(r.sessionId, {
-          bestScore: r.score,
-          bestTurnIndex: r.turnIndex,
+        sessionMap.set(sessionId, {
+          bestScore: score,
+          bestTurnIndex: this.turnIndices[i],
           matchCount: 1,
         });
       }

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -1,0 +1,373 @@
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MODEL_NAME = "Snowflake/snowflake-arctic-embed-m-v2.0";
+export const EMBEDDING_DIMS = 256;
+
+/** Minimal interface for the db methods VectorIndex needs. */
+export interface EmbeddingDb {
+  loadAllEmbeddings(): {
+    sessionIds: string[];
+    turnIndices: number[];
+    roles: string[];
+    embeddings: Float32Array[];
+  };
+}
+
+// ---------------------------------------------------------------------------
+// EmbeddingEngine — lazy-loading singleton for ONNX model inference
+// ---------------------------------------------------------------------------
+
+/** Singleton embedding engine. Lazy-loads model on first use. */
+export class EmbeddingEngine {
+  private extractor: unknown | null = null;
+  private readyPromise: Promise<void>;
+  private resolveReady!: () => void;
+  private rejectReady!: (err: Error) => void;
+  private loaded = false;
+  private failed = false;
+  private disabled = false;
+
+  constructor() {
+    this.readyPromise = new Promise<void>((resolve, reject) => {
+      this.resolveReady = resolve;
+      this.rejectReady = reject;
+    });
+
+    // Allow users to opt out on constrained machines
+    if (process.env.GLOSS_NO_EMBEDDINGS) {
+      this.disabled = true;
+      this.failed = true;
+      console.log("[embeddings] Disabled via GLOSS_NO_EMBEDDINGS");
+      this.rejectReady(new Error("Embeddings disabled via GLOSS_NO_EMBEDDINGS"));
+      return;
+    }
+
+    this._init();
+  }
+
+  private async _init(): Promise<void> {
+    try {
+      // Dynamic import to avoid top-level blocking.
+      // Try native ONNX runtime first, fall back to WASM if N-API fails in Bun.
+      const { pipeline, env } = await import("@huggingface/transformers");
+      try {
+        this.extractor = await pipeline("feature-extraction", MODEL_NAME, {
+          dtype: "q8",
+        });
+      } catch (nativeErr) {
+        console.warn(`[embeddings] Native ONNX failed, trying WASM fallback: ${nativeErr instanceof Error ? nativeErr.message : nativeErr}`);
+        if (env.backends?.onnx?.wasm) {
+          env.backends.onnx.wasm.numThreads = 1;
+        }
+        this.extractor = await pipeline("feature-extraction", MODEL_NAME, {
+          dtype: "q8",
+          device: "wasm",
+        });
+      }
+      this.loaded = true;
+      this.resolveReady();
+      console.log(`[embeddings] Model loaded: ${MODEL_NAME}`);
+    } catch (err) {
+      this.failed = true;
+      const error = err instanceof Error ? err : new Error(String(err));
+      console.error(`[embeddings] Failed to load model: ${error.message}`);
+      this.rejectReady(error);
+    }
+  }
+
+  /** Returns true once the model is loaded and ready. */
+  isReady(): boolean {
+    return this.loaded;
+  }
+
+  /** Returns true if model loading failed. */
+  hasFailed(): boolean {
+    return this.failed;
+  }
+
+  /** Wait for model to finish loading. */
+  async waitReady(): Promise<void> {
+    return this.readyPromise;
+  }
+
+  /**
+   * Embed one or more text strings. Returns array of Float32Array(256).
+   * Handles batching internally. Truncates input to model's max tokens.
+   */
+  async embed(texts: string[]): Promise<Float32Array[]> {
+    if (!this.loaded || !this.extractor) {
+      throw new Error("Embedding engine not ready");
+    }
+
+    if (texts.length === 0) return [];
+
+    // Truncate each text to ~2000 chars for practical embedding size
+    const truncated = texts.map((t) =>
+      t.length > 2000 ? t.slice(0, 2000) : t,
+    );
+
+    const extractor = this.extractor as (
+      texts: string[],
+      options: { pooling: string; normalize: boolean },
+    ) => Promise<{ tolist(): number[][] }>;
+
+    const output = await extractor(truncated, {
+      pooling: "cls",
+      normalize: true,
+    });
+
+    const fullVectors = output.tolist();
+    // Matryoshka truncation: take first 256 dims, then L2-normalize
+    return fullVectors.map((vec) => truncateAndNormalize(vec));
+  }
+
+  /**
+   * Embed a single query string. Applies the "query: " prefix
+   * required by snowflake-arctic-embed for asymmetric retrieval.
+   */
+  async embedQuery(query: string): Promise<Float32Array> {
+    const prefixed = `query: ${query}`;
+    const results = await this.embed([prefixed]);
+    return results[0];
+  }
+
+  /** Release model resources. */
+  dispose(): void {
+    this.extractor = null;
+    this.loaded = false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Vector math helpers
+// ---------------------------------------------------------------------------
+
+/** Truncate to EMBEDDING_DIMS and L2-normalize. */
+function truncateAndNormalize(vec: number[]): Float32Array {
+  const out = new Float32Array(EMBEDDING_DIMS);
+  let norm = 0;
+  for (let i = 0; i < EMBEDDING_DIMS; i++) {
+    out[i] = vec[i];
+    norm += vec[i] * vec[i];
+  }
+  norm = Math.sqrt(norm);
+  if (norm > 0) {
+    for (let i = 0; i < EMBEDDING_DIMS; i++) {
+      out[i] /= norm;
+    }
+  }
+  return out;
+}
+
+/** Dot product of two Float32Arrays of equal length. */
+function dot(a: Float32Array, b: Float32Array): number {
+  let sum = 0;
+  for (let i = 0; i < a.length; i++) {
+    sum += a[i] * b[i];
+  }
+  return sum;
+}
+
+// ---------------------------------------------------------------------------
+// VectorSearchResult
+// ---------------------------------------------------------------------------
+
+export interface VectorSearchResult {
+  sessionId: string;
+  turnIndex: number;
+  role: string;
+  score: number; // cosine similarity, 0-1
+}
+
+// ---------------------------------------------------------------------------
+// VectorIndex — in-memory brute-force cosine search
+// ---------------------------------------------------------------------------
+
+/**
+ * In-memory vector index for fast cosine similarity search.
+ * Stores all embeddings in flat typed arrays for cache-friendly scanning.
+ */
+export class VectorIndex {
+  private sessionIds: string[];
+  private turnIndices: number[];
+  private roles: string[];
+  private vectors: Float32Array; // flat buffer: N × 256
+  private _count: number;
+
+  private constructor(
+    sessionIds: string[],
+    turnIndices: number[],
+    roles: string[],
+    vectors: Float32Array,
+    count: number,
+  ) {
+    this.sessionIds = sessionIds;
+    this.turnIndices = turnIndices;
+    this.roles = roles;
+    this.vectors = vectors;
+    this._count = count;
+  }
+
+  /** Number of vectors in the index. */
+  get count(): number {
+    return this._count;
+  }
+
+  /** Load all embeddings from the database into memory. */
+  static fromDb(db: EmbeddingDb): VectorIndex {
+    const data = db.loadAllEmbeddings();
+    const count = data.sessionIds.length;
+    // Flatten embeddings into a single contiguous buffer
+    const flat = new Float32Array(count * EMBEDDING_DIMS);
+    for (let i = 0; i < count; i++) {
+      flat.set(data.embeddings[i], i * EMBEDDING_DIMS);
+    }
+    return new VectorIndex(
+      data.sessionIds,
+      data.turnIndices,
+      data.roles,
+      flat,
+      count,
+    );
+  }
+
+  /** Remove all vectors for a session (used before re-indexing). */
+  removeSession(sessionId: string): void {
+    // Find indices to keep (everything except this session)
+    const keepIndices: number[] = [];
+    for (let i = 0; i < this._count; i++) {
+      if (this.sessionIds[i] !== sessionId) {
+        keepIndices.push(i);
+      }
+    }
+    if (keepIndices.length === this._count) return; // nothing to remove
+
+    const newCount = keepIndices.length;
+    const newVectors = new Float32Array(newCount * EMBEDDING_DIMS);
+    const newSessionIds: string[] = [];
+    const newTurnIndices: number[] = [];
+    const newRoles: string[] = [];
+
+    for (let j = 0; j < keepIndices.length; j++) {
+      const i = keepIndices[j];
+      newSessionIds.push(this.sessionIds[i]);
+      newTurnIndices.push(this.turnIndices[i]);
+      newRoles.push(this.roles[i]);
+      const src = this.vectors.subarray(i * EMBEDDING_DIMS, (i + 1) * EMBEDDING_DIMS);
+      newVectors.set(src, j * EMBEDDING_DIMS);
+    }
+
+    this.sessionIds = newSessionIds;
+    this.turnIndices = newTurnIndices;
+    this.roles = newRoles;
+    this.vectors = newVectors;
+    this._count = newCount;
+  }
+
+  /** Add vectors for a newly-indexed session (removes stale vectors first). */
+  addSession(
+    sessionId: string,
+    entries: Array<{
+      turnIndex: number;
+      role: string;
+      embedding: Float32Array;
+    }>,
+  ): void {
+    if (entries.length === 0) return;
+
+    // Remove stale vectors for this session before appending new ones
+    this.removeSession(sessionId);
+
+    const newCount = this._count + entries.length;
+    const newVectors = new Float32Array(newCount * EMBEDDING_DIMS);
+    newVectors.set(this.vectors);
+
+    for (let i = 0; i < entries.length; i++) {
+      const entry = entries[i];
+      this.sessionIds.push(sessionId);
+      this.turnIndices.push(entry.turnIndex);
+      this.roles.push(entry.role);
+      newVectors.set(entry.embedding, (this._count + i) * EMBEDDING_DIMS);
+    }
+
+    this.vectors = newVectors;
+    this._count = newCount;
+  }
+
+  /**
+   * Find top-K turns most similar to the query vector.
+   * Returns results sorted by score descending.
+   */
+  search(queryVector: Float32Array, topK = 50): VectorSearchResult[] {
+    if (this._count === 0) return [];
+
+    // Score all vectors (vectors are pre-normalized, so dot = cosine sim)
+    const scores: Array<{ idx: number; score: number }> = [];
+    for (let i = 0; i < this._count; i++) {
+      const offset = i * EMBEDDING_DIMS;
+      const vec = this.vectors.subarray(offset, offset + EMBEDDING_DIMS);
+      const score = dot(queryVector, vec);
+      scores.push({ idx: i, score });
+    }
+
+    // Partial sort: find top K
+    scores.sort((a, b) => b.score - a.score);
+    const top = scores.slice(0, topK);
+
+    return top.map(({ idx, score }) => ({
+      sessionId: this.sessionIds[idx],
+      turnIndex: this.turnIndices[idx],
+      role: this.roles[idx],
+      score,
+    }));
+  }
+
+  /**
+   * Aggregate turn-level results to session-level.
+   * Returns sessions ranked by their best turn's score.
+   */
+  searchSessions(
+    queryVector: Float32Array,
+    topK = 30,
+  ): Array<{
+    sessionId: string;
+    bestScore: number;
+    bestTurnIndex: number;
+    matchCount: number;
+  }> {
+    // Get more turn-level results to ensure good session coverage
+    const turnResults = this.search(queryVector, topK * 5);
+
+    // Aggregate by session
+    const sessionMap = new Map<
+      string,
+      { bestScore: number; bestTurnIndex: number; matchCount: number }
+    >();
+
+    for (const r of turnResults) {
+      const existing = sessionMap.get(r.sessionId);
+      if (existing) {
+        existing.matchCount++;
+        if (r.score > existing.bestScore) {
+          existing.bestScore = r.score;
+          existing.bestTurnIndex = r.turnIndex;
+        }
+      } else {
+        sessionMap.set(r.sessionId, {
+          bestScore: r.score,
+          bestTurnIndex: r.turnIndex,
+          matchCount: 1,
+        });
+      }
+    }
+
+    // Sort by best score descending
+    const results = [...sessionMap.entries()]
+      .map(([sessionId, data]) => ({ sessionId, ...data }))
+      .sort((a, b) => b.bestScore - a.bestScore);
+
+    return results.slice(0, topK);
+  }
+}

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -93,7 +93,9 @@ export class EmbeddingEngine {
 
       // Handle subprocess exit
       this.subprocess.exited.then((code) => {
-        if (!this.loaded && !this.failed) {
+        this.loaded = false;
+        this.subprocessReady = false;
+        if (!this.failed) {
           this.failed = true;
           this.rejectReady(new Error(`Embedding subprocess exited with code ${code}`));
         }
@@ -103,7 +105,6 @@ export class EmbeddingEngine {
         }
         this.pending.clear();
         this.subprocess = null;
-        this.subprocessReady = false;
       });
     } catch (err) {
       this.failed = true;
@@ -175,8 +176,13 @@ export class EmbeddingEngine {
       const promise = new Promise<Float32Array[]>((resolve, reject) => {
         this.pending.set(id, { resolve, reject });
       });
-      const msg = JSON.stringify({ id, texts }) + "\n";
-      this.subprocess.stdin.write(msg);
+      try {
+        this.subprocess.stdin.write(JSON.stringify({ id, texts }) + "\n");
+      } catch (err) {
+        this.pending.delete(id);
+        this.subprocessReady = false;
+        throw new Error("Embedding subprocess stdin write failed");
+      }
       return promise;
     }
     throw new Error("Embedding subprocess not available");

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -2,7 +2,6 @@
 // Constants
 // ---------------------------------------------------------------------------
 
-const MODEL_NAME = "Snowflake/snowflake-arctic-embed-m-v2.0";
 export const EMBEDDING_DIMS = 256;
 
 /** Minimal interface for the db methods VectorIndex needs. */
@@ -16,18 +15,31 @@ export interface EmbeddingDb {
 }
 
 // ---------------------------------------------------------------------------
-// EmbeddingEngine — lazy-loading singleton for ONNX model inference
+// EmbeddingEngine — subprocess-only ONNX model inference
 // ---------------------------------------------------------------------------
 
-/** Singleton embedding engine. Lazy-loads model on first use. */
+/**
+ * Embedding engine that runs the ONNX model exclusively in a subprocess
+ * (embedding-worker.ts) to avoid blocking the main event loop and to
+ * prevent loading the ~4 GB model twice.
+ */
 export class EmbeddingEngine {
-  private extractor: unknown | null = null;
   private readyPromise: Promise<void>;
   private resolveReady!: () => void;
   private rejectReady!: (err: Error) => void;
   private loaded = false;
   private failed = false;
   private disabled = false;
+
+  // Subprocess state
+  private subprocess: ReturnType<typeof Bun.spawn> | null = null;
+  private subprocessReady = false;
+  private nextId = 1;
+  private pending = new Map<
+    number,
+    { resolve: (v: Float32Array[]) => void; reject: (e: Error) => void }
+  >();
+  private stdoutBuffer = "";
 
   constructor() {
     this.readyPromise = new Promise<void>((resolve, reject) => {
@@ -46,40 +58,98 @@ export class EmbeddingEngine {
       return;
     }
 
-    this._init();
+    this._initSubprocess();
   }
 
-  private async _init(): Promise<void> {
+  private _initSubprocess(): void {
     try {
-      // Dynamic import to avoid top-level blocking.
-      // Try native ONNX runtime first, fall back to WASM if N-API fails in Bun.
-      const { pipeline, env } = await import("@huggingface/transformers");
-      try {
-        this.extractor = await pipeline("feature-extraction", MODEL_NAME, {
-          dtype: "q8",
-        });
-      } catch (nativeErr) {
-        console.warn(`[embeddings] Native ONNX failed, trying WASM fallback: ${nativeErr instanceof Error ? nativeErr.message : nativeErr}`);
-        if (env.backends?.onnx?.wasm) {
-          env.backends.onnx.wasm.numThreads = 1;
+      const workerPath = new URL("./embedding-worker.ts", import.meta.url).pathname;
+      this.subprocess = Bun.spawn(["bun", "run", workerPath], {
+        stdin: "pipe",
+        stdout: "pipe",
+        stderr: "inherit",
+      });
+
+      // Read stdout as text stream
+      const reader = this.subprocess.stdout.getReader();
+      const decoder = new TextDecoder();
+      const readLoop = async () => {
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            this.stdoutBuffer += decoder.decode(value, { stream: true });
+            const lines = this.stdoutBuffer.split("\n");
+            this.stdoutBuffer = lines.pop() || "";
+            for (const line of lines) {
+              if (line.trim()) this._handleMessage(line);
+            }
+          }
+        } catch {
+          // subprocess exited
         }
-        this.extractor = await pipeline("feature-extraction", MODEL_NAME, {
-          dtype: "q8",
-          device: "wasm",
-        });
-      }
-      this.loaded = true;
-      this.resolveReady();
-      console.log(`[embeddings] Model loaded: ${MODEL_NAME}`);
+      };
+      readLoop();
+
+      // Handle subprocess exit
+      this.subprocess.exited.then((code) => {
+        if (!this.loaded && !this.failed) {
+          this.failed = true;
+          this.rejectReady(new Error(`Embedding subprocess exited with code ${code}`));
+        }
+        // Reject any pending requests
+        for (const [, pending] of this.pending) {
+          pending.reject(new Error("Embedding subprocess exited"));
+        }
+        this.pending.clear();
+        this.subprocess = null;
+        this.subprocessReady = false;
+      });
     } catch (err) {
       this.failed = true;
       const error = err instanceof Error ? err : new Error(String(err));
-      console.error(`[embeddings] Failed to load model: ${error.message}`);
+      console.error(`[embeddings] Failed to spawn subprocess: ${error.message}`);
       this.rejectReady(error);
     }
   }
 
-  /** Returns true once the model is loaded and ready. */
+  private _handleMessage(line: string): void {
+    let msg: any;
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      return;
+    }
+
+    if (msg.type === "ready") {
+      this.subprocessReady = true;
+      this.loaded = true;
+      this.resolveReady();
+      console.log("[embeddings] Subprocess model loaded");
+      return;
+    }
+
+    if (msg.type === "status") {
+      console.log(`[embeddings] ${msg.message}`);
+      return;
+    }
+
+    // Response to an embed request: { id, embeddings } or { id, error }
+    const pending = this.pending.get(msg.id);
+    if (!pending) return;
+    this.pending.delete(msg.id);
+
+    if (msg.error) {
+      pending.reject(new Error(msg.error));
+    } else if (msg.embeddings) {
+      const results = (msg.embeddings as number[][]).map(
+        (vec) => new Float32Array(vec),
+      );
+      pending.resolve(results);
+    }
+  }
+
+  /** Returns true once the subprocess model is loaded and ready. */
   isReady(): boolean {
     return this.loaded;
   }
@@ -89,40 +159,27 @@ export class EmbeddingEngine {
     return this.failed;
   }
 
-  /** Wait for model to finish loading. */
+  /** Wait for subprocess model to finish loading. */
   async waitReady(): Promise<void> {
     return this.readyPromise;
   }
 
   /**
-   * Embed one or more text strings. Returns array of Float32Array(256).
-   * Handles batching internally. Truncates input to model's max tokens.
+   * Embed texts off the main thread via the subprocess.
+   * Returns array of Float32Array(256).
    */
-  async embed(texts: string[]): Promise<Float32Array[]> {
-    if (!this.loaded || !this.extractor) {
-      throw new Error("Embedding engine not ready");
-    }
-
+  async embedOffThread(texts: string[]): Promise<Float32Array[]> {
     if (texts.length === 0) return [];
-
-    // Truncate each text to ~2000 chars for practical embedding size
-    const truncated = texts.map((t) =>
-      t.length > 2000 ? t.slice(0, 2000) : t,
-    );
-
-    const extractor = this.extractor as (
-      texts: string[],
-      options: { pooling: string; normalize: boolean },
-    ) => Promise<{ tolist(): number[][] }>;
-
-    const output = await extractor(truncated, {
-      pooling: "cls",
-      normalize: true,
-    });
-
-    const fullVectors = output.tolist();
-    // Matryoshka truncation: take first 256 dims, then L2-normalize
-    return fullVectors.map((vec) => truncateAndNormalize(vec));
+    if (this.subprocess && this.subprocessReady) {
+      const id = this.nextId++;
+      const promise = new Promise<Float32Array[]>((resolve, reject) => {
+        this.pending.set(id, { resolve, reject });
+      });
+      const msg = JSON.stringify({ id, texts }) + "\n";
+      this.subprocess.stdin.write(msg);
+      return promise;
+    }
+    throw new Error("Embedding subprocess not available");
   }
 
   /**
@@ -130,14 +187,22 @@ export class EmbeddingEngine {
    * required by snowflake-arctic-embed for asymmetric retrieval.
    */
   async embedQuery(query: string): Promise<Float32Array> {
-    const prefixed = `query: ${query}`;
-    const results = await this.embed([prefixed]);
+    if (!this.loaded) throw new Error("Embedding engine not ready");
+    const results = await this.embedOffThread([`query: ${query}`]);
     return results[0];
   }
 
-  /** Release model resources. */
+  /** Release subprocess resources. */
   dispose(): void {
-    this.extractor = null;
+    if (this.subprocess) {
+      try {
+        this.subprocess.kill();
+      } catch {
+        // already dead
+      }
+      this.subprocess = null;
+    }
+    this.subprocessReady = false;
     this.loaded = false;
   }
 }

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -1,0 +1,181 @@
+import * as fs from "node:fs";
+import * as crypto from "node:crypto";
+import { IncrementalParser } from "./incremental-parser.js";
+import type { ConvoDb } from "./db.js";
+import type { EmbeddingEngine, VectorIndex } from "./embeddings.js";
+import type { TextBlock } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Max file size for embedding indexing (100MB). Larger files skipped. */
+const EMBEDDING_INDEX_LIMIT = 100 * 1024 * 1024;
+
+/** Max characters per turn to embed (practical truncation limit). */
+const MAX_TURN_CHARS = 2000;
+
+/** Number of turns per embedding batch call. */
+const DEFAULT_BATCH_SIZE = 32;
+
+// ---------------------------------------------------------------------------
+// Turn text extraction
+// ---------------------------------------------------------------------------
+
+/** Extract embeddable text from a turn (text blocks only, no tools/thinking). */
+function turnToEmbeddingText(blocks: Array<{ type: string; text?: string }>): string {
+  return blocks
+    .filter((b): b is TextBlock => b.type === "text")
+    .map((b) => b.text || "")
+    .join("\n")
+    .trim();
+}
+
+/** SHA-256 hash of text for dedup/staleness detection. */
+function textHash(text: string): string {
+  return crypto.createHash("sha256").update(text).digest("hex");
+}
+
+// ---------------------------------------------------------------------------
+// Background embedding indexer
+// ---------------------------------------------------------------------------
+
+/**
+ * Background embedding indexer. Scans sessions and generates embeddings.
+ * Modeled after backfillFtsIndex() in discovery.ts.
+ */
+export function backfillEmbeddings(
+  db: ConvoDb,
+  engine: EmbeddingEngine,
+  vectorIndex: VectorIndex | null,
+  options?: {
+    batchSize?: number;
+    onProgress?: (indexed: number, total: number) => void;
+  },
+): void {
+  if (!engine.isReady()) {
+    console.log("[embeddings] Engine not ready, skipping backfill");
+    return;
+  }
+
+  const batchSize = options?.batchSize ?? DEFAULT_BATCH_SIZE;
+
+  // listSessions returns sessions ordered by last_modified DESC,
+  // so recent conversations get embedded first during initial backfill.
+  const sessions = db.listSessions({}) as Array<{
+    id: string;
+    jsonl_path?: string | null;
+    file_size?: number | null;
+  }>;
+
+  // Find sessions needing embedding
+  const needsIndexing: Array<{ id: string; jsonl_path: string; mtime: number }> = [];
+  for (const s of sessions) {
+    if (!s.jsonl_path) continue;
+    try {
+      const stat = fs.statSync(s.jsonl_path);
+      if (!stat.isFile() || stat.size > EMBEDDING_INDEX_LIMIT) continue;
+      const mtime = Math.floor(stat.mtimeMs / 1000);
+      if (db.embeddingNeedsIndexing(s.id, mtime)) {
+        needsIndexing.push({ id: s.id, jsonl_path: s.jsonl_path, mtime });
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  if (needsIndexing.length === 0) return;
+
+  // Sort by mtime descending so recent conversations get embedded first
+  needsIndexing.sort((a, b) => b.mtime - a.mtime);
+
+  console.log(`Embedding ${needsIndexing.length} sessions...`);
+  let i = 0;
+  let indexed = 0;
+  let totalTurns = 0;
+
+  const processSession = async () => {
+    if (i >= needsIndexing.length) {
+      console.log(`Embeddings: ${indexed} sessions indexed (${totalTurns} turns)`);
+      return;
+    }
+
+    const s = needsIndexing[i];
+    i++;
+
+    try {
+      const content = fs.readFileSync(s.jsonl_path, "utf-8");
+      const parser = new IncrementalParser();
+      parser.feedLines(content.split("\n"));
+      const turns = parser.getTurns();
+
+      // Extract text and filter empty turns
+      const turnTexts: Array<{ index: number; role: string; text: string; hash: string }> = [];
+      for (let t = 0; t < turns.length; t++) {
+        const text = turnToEmbeddingText(turns[t].blocks);
+        if (!text) continue;
+        const truncated = text.length > MAX_TURN_CHARS ? text.slice(0, MAX_TURN_CHARS) : text;
+        turnTexts.push({
+          index: t,
+          role: turns[t].role,
+          text: truncated,
+          hash: textHash(truncated),
+        });
+      }
+
+      if (turnTexts.length === 0) {
+        setTimeout(processSession, 10);
+        return;
+      }
+
+      // Embed in batches
+      const entries: Array<{
+        turnIndex: number;
+        role: string;
+        textHash: string;
+        embedding: Float32Array;
+      }> = [];
+
+      for (let b = 0; b < turnTexts.length; b += batchSize) {
+        const batch = turnTexts.slice(b, b + batchSize);
+        const texts = batch.map((t) => t.text);
+        const embeddings = await engine.embed(texts);
+        for (let j = 0; j < batch.length; j++) {
+          entries.push({
+            turnIndex: batch[j].index,
+            role: batch[j].role,
+            textHash: batch[j].hash,
+            embedding: embeddings[j],
+          });
+        }
+      }
+
+      // Store in DB
+      db.storeEmbeddings(s.id, entries, s.mtime);
+
+      // Update in-memory vector index if available
+      if (vectorIndex) {
+        vectorIndex.addSession(
+          s.id,
+          entries.map((e) => ({
+            turnIndex: e.turnIndex,
+            role: e.role,
+            embedding: e.embedding,
+          })),
+        );
+      }
+
+      indexed++;
+      totalTurns += entries.length;
+      options?.onProgress?.(indexed, needsIndexing.length);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[embeddings] Error indexing session ${s.id}: ${msg}`);
+    }
+
+    // Yield to event loop between sessions
+    setTimeout(processSession, 10);
+  };
+
+  processSession();
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,8 @@ import { escape } from "./markdown.js";
 import { openDb, type ConvoDb } from "./db.js";
 import { scanProjectsDir, syncToDb, backfillTurnCounts, backfillFtsIndex } from "./discovery.js";
 import { buildServerIndex } from "./index-page.js";
+import { EmbeddingEngine, VectorIndex } from "./embeddings.js";
+import { backfillEmbeddings } from "./indexer.js";
 import type { Turn, TextBlock, TocEntry } from "./types.js";
 import type { ServerWebSocket } from "bun";
 
@@ -220,10 +222,44 @@ export async function startServer(options: { port?: number } = {}): Promise<void
   // Import legacy sidecar annotations
   importLegacySidecars(db);
 
-  // Background: count turns, then index for FTS
+  // Initialize embedding engine unless explicitly disabled
+  const embeddingsDisabled = !!process.env.GLOSS_NO_EMBEDDINGS;
+  let embeddingEngine: EmbeddingEngine | undefined;
+  let vectorIndex: VectorIndex | null = null;
+
+  if (!embeddingsDisabled) {
+    embeddingEngine = new EmbeddingEngine();
+
+    // Load existing embeddings into memory
+    try {
+      vectorIndex = VectorIndex.fromDb(db);
+      if (vectorIndex.count > 0) {
+        console.log(`Loaded ${vectorIndex.count} embeddings into vector index`);
+      }
+    } catch {
+      // first run, no embeddings yet
+    }
+  }
+
+  /** Kick off embedding backfill if engine is ready. */
+  const startEmbeddingBackfill = () => {
+    if (!embeddingEngine) return;
+    if (embeddingEngine.isReady()) {
+      backfillEmbeddings(db, embeddingEngine, vectorIndex);
+    } else {
+      // Wait for engine to load, then backfill
+      embeddingEngine.waitReady().then(() => {
+        backfillEmbeddings(db, embeddingEngine!, vectorIndex);
+      }).catch(() => {
+        // Model failed to load — skip embeddings entirely
+      });
+    }
+  };
+
+  // Background: count turns, then FTS, then embeddings
   setTimeout(() => {
     backfillTurnCounts(db);
-    setTimeout(() => backfillFtsIndex(db), 2000);
+    setTimeout(() => backfillFtsIndex(db, startEmbeddingBackfill), 2000);
   }, 500);
 
   // Periodic rescan
@@ -231,10 +267,10 @@ export async function startServer(options: { port?: number } = {}): Promise<void
     try {
       const freshSessions = scanProjectsDir();
       syncToDb(db, freshSessions);
-      // Backfill turns and FTS for any new sessions
+      // Backfill turns, FTS, then embeddings for any new sessions
       setTimeout(() => {
         backfillTurnCounts(db);
-        setTimeout(() => backfillFtsIndex(db), 2000);
+        setTimeout(() => backfillFtsIndex(db, startEmbeddingBackfill), 2000);
       }, 500);
     } catch {
       // best-effort
@@ -286,7 +322,7 @@ export async function startServer(options: { port?: number } = {}): Promise<void
 
       // API routes
       if (pathname.startsWith("/api/")) {
-        return handleApiRoute(req, pathname, db);
+        return handleApiRoute(req, pathname, db, { embeddingEngine, vectorIndex });
       }
 
       // Conversation page: /c/:sessionId
@@ -488,6 +524,7 @@ export async function handleApiRoute(
   req: Request,
   pathname: string,
   db: ConvoDb,
+  search?: { embeddingEngine?: EmbeddingEngine; vectorIndex?: VectorIndex | null },
 ): Promise<Response> {
   const jsonHeaders = { "Content-Type": "application/json; charset=utf-8" };
 
@@ -590,6 +627,8 @@ export async function handleApiRoute(
     const { askQuestion } = await import("./ask.js");
     const result = await askQuestion(db, q, {
       maxSources: (body.maxSources as number) ?? undefined,
+      vectorIndex: search?.vectorIndex ?? undefined,
+      embeddingEngine: search?.embeddingEngine,
     });
     return new Response(JSON.stringify(result), { headers: jsonHeaders });
   }
@@ -605,7 +644,10 @@ export async function handleApiRoute(
     }
     const { askQuestion } = await import("./ask.js");
     const { buildAskResultsHtml } = await import("./ask-page.js");
-    const result = await askQuestion(db, q);
+    const result = await askQuestion(db, q, {
+      vectorIndex: search?.vectorIndex ?? undefined,
+      embeddingEngine: search?.embeddingEngine,
+    });
     const html = buildAskResultsHtml(result);
     return new Response(html, {
       headers: { "Content-Type": "text/html; charset=utf-8" },


### PR DESCRIPTION
## Summary
- **Removed main-thread ONNX model loading** (`_init()`, `extractor` field, `embed()` method) from `EmbeddingEngine` to eliminate ~4GB RAM duplication and event loop blocking
- **Added subprocess IPC** via `_initSubprocess()` using `Bun.spawn` + newline-delimited JSON to route all embedding through `embedding-worker.ts`
- **`embedQuery()`** now delegates to `embedOffThread()` with the `"query: "` prefix applied before sending to subprocess
- **`isReady()`/`waitReady()`** now track subprocess readiness instead of main-thread model state
- **`embedOffThread()`** throws if subprocess is unavailable (no silent fallback to removed `embed()`)
- **`dispose()`** kills the subprocess instead of nulling the removed extractor
- **No changes** to `embedding-worker.ts` (subprocess protocol unchanged)

## Interface contract (unchanged signatures)
- `embedQuery(query: string): Promise<Float32Array>`
- `embedOffThread(texts: string[]): Promise<Float32Array[]>`
- `isReady(): boolean`
- `waitReady(): Promise<void>`

## Test plan
- [x] All 263 existing tests pass (`bun test`)
- [x] No `extractor` field in `embeddings.ts`
- [x] No `_init()` method in `embeddings.ts`
- [x] No `import("@huggingface/transformers")` in `embeddings.ts` (only in `embedding-worker.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)